### PR TITLE
some changes to api namespaces exclusion list PR

### DIFF
--- a/business/namespaces.go
+++ b/business/namespaces.go
@@ -49,15 +49,19 @@ func (in *NamespaceService) GetNamespaces() ([]models.Namespace, error) {
 		namespaces = models.CastNamespaceCollection(services)
 	}
 
-	result := []models.Namespace{}
-NAMESPACES:
-	for _, namespace := range namespaces {
-		for _, excludePattern := range config.Get().Api.Namespaces.Exclude {
-			if match, _ := regexp.MatchString(excludePattern, namespace.Name); match {
-				continue NAMESPACES
+	result := namespaces
+	excludes := config.Get().Api.Namespaces.Exclude
+	if len(excludes) > 0 {
+		result = []models.Namespace{}
+	NAMESPACES:
+		for _, namespace := range namespaces {
+			for _, excludePattern := range excludes {
+				if match, _ := regexp.MatchString(excludePattern, namespace.Name); match {
+					continue NAMESPACES
+				}
 			}
+			result = append(result, namespace)
 		}
-		result = append(result, namespace)
 	}
 
 	return result, nil

--- a/config.yaml
+++ b/config.yaml
@@ -46,11 +46,3 @@ external_services:
   # Uncomment service_label_name to set up a different label name for grouping all resources of an app version.
   # Default is "version"
   # version_label_name: version
-
-# Update list to add or remove namespaces. Blacklisted namespaces will not be displayed by default. Regex supported.
-api_config:
-  namespaces:
-    exclude:
-    - default
-    - istio-operator
-    - kube.*

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ const (
 	EnvIstioIdentityDomain    = "ISTIO_IDENTITY_DOMAIN"
 	EnvIstioSidecarAnnotation = "ISTIO_SIDECAR_ANNOTATION"
 	EnvIstioUrlServiceVersion = "ISTIO_URL_SERVICE_VERSION"
+	EnvApiNamespacesExclude   = "API_NAMESPACES_EXCLUDE"
 
 	EnvServerAddress                    = "SERVER_ADDRESS"
 	EnvServerPort                       = "SERVER_PORT"
@@ -160,6 +161,7 @@ func NewConfig() (c *Config) {
 	c.IstioNamespace = strings.TrimSpace(getDefaultString(EnvIstioNamespace, "istio-system"))
 	c.IstioLabels.AppLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameApp, "app"))
 	c.IstioLabels.VersionLabelName = strings.TrimSpace(getDefaultString(EnvIstioLabelNameVersion, "version"))
+	c.Api.Namespaces.Exclude = getDefaultStringArray(EnvApiNamespacesExclude, "default,istio-operator,kube.*,openshift.*")
 
 	// Server configuration
 	c.Server.Address = strings.TrimSpace(getDefaultString(EnvServerAddress, ""))
@@ -231,6 +233,15 @@ func getDefaultString(envvar string, defaultValue string) (retVal string) {
 	if retVal == "" {
 		retVal = defaultValue
 	}
+	return
+}
+
+func getDefaultStringArray(envvar string, defaultValue string) (retVal []string) {
+	csv := os.Getenv(envvar)
+	if csv == "" {
+		csv = defaultValue
+	}
+	retVal = strings.Split(csv, ",")
 	return
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,8 +41,16 @@ func TestDefaults(t *testing.T) {
 		t.Error("server CORS default setting is wrong")
 	}
 
-	if len(conf.Api.Namespaces.Exclude) != 0 {
+	if len(conf.Api.Namespaces.Exclude) != 4 {
 		t.Error("Api namespace exclude default setting is wrong")
+	} else {
+		// our default exclusion list: default,istio-operator,kube.*,openshift.*
+		if conf.Api.Namespaces.Exclude[0] != "default" ||
+			conf.Api.Namespaces.Exclude[1] != "istio-operator" ||
+			conf.Api.Namespaces.Exclude[2] != "kube.*" ||
+			conf.Api.Namespaces.Exclude[3] != "openshift.*" {
+			t.Errorf("Api namespace exclude default list is wrong: %+v", conf.Api.Namespaces.Exclude)
+		}
 	}
 }
 

--- a/deploy/kubernetes/kiali-configmap.yaml
+++ b/deploy/kubernetes/kiali-configmap.yaml
@@ -15,9 +15,3 @@ data:
         url: ${JAEGER_URL}
       grafana:
         url: ${GRAFANA_URL}
-    api_config:
-      namespaces:
-        exclude:
-        - default
-        - istio-operator
-        - kube.*

--- a/deploy/openshift/kiali-configmap.yaml
+++ b/deploy/openshift/kiali-configmap.yaml
@@ -18,10 +18,3 @@ data:
     identity:
       cert_file: /kiali-cert/tls.crt
       private_key_file: /kiali-cert/tls.key
-    api:
-      namespaces:
-        exclude:
-        - default
-        - istio-operator
-        - kube.*
-        - openshift.*


### PR DESCRIPTION
1. support default exclusion list and env var override like the other settings
2. only call Get().Api one time - not once for every namespace we get.
3. skip looping over namespaces if we know there is no exclusion list