### PR TITLE
Removed Cluster from App lists critera not to used in config ist

### DIFF
--- a/handlers/apps.go
+++ b/handlers/apps.go
@@ -49,7 +49,7 @@ func AppList(w http.ResponseWriter, r *http.Request) {
 	p.extract(r)
 
 	criteria := business.AppCriteria{Namespace: p.Namespace, IncludeIstioResources: p.IncludeIstioResources,
-		IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime, Cluster: p.Cluster}
+		IncludeHealth: p.IncludeHealth, RateInterval: p.RateInterval, QueryTime: p.QueryTime}
 
 	// Get business layer
 	business, err := getBusiness(r)


### PR DESCRIPTION
AppList comes without cluster param, and with the default valued Cluster in AppCriteria it was causing "GetIstioConfigMap" call return Istio configs only for default cluster.