### PR TITLE
Polish target panel UI styling

### DIFF
--- a/frontend/src/components/Nav/Navigation.tsx
+++ b/frontend/src/components/Nav/Navigation.tsx
@@ -27,12 +27,17 @@ import { Menu } from './Menu';
 import { Link } from 'react-router-dom';
 import { ExternalServiceInfo } from '../../types/StatusState';
 
-type PropsType = RouteComponentProps & {
-  navCollapsed: boolean;
-  setNavCollapsed: (collapse: boolean) => void;
-  tracingUrl?: string;
+type ReduxStateProps = {
   externalServices: ExternalServiceInfo[];
+  navCollapsed: boolean;
+  tracingUrl?: string;
 };
+
+type ReduxDispatchProps = {
+  setNavCollapsed: (collapse: boolean) => void;
+};
+
+type PropsType = RouteComponentProps & ReduxStateProps & ReduxDispatchProps;
 
 type NavigationState = {
   isMobileView: boolean;
@@ -47,7 +52,7 @@ const flexBoxColumnStyle = kialiStyle({
 
 export class NavigationComponent extends React.Component<PropsType, NavigationState> {
   static contextTypes = {
-    router: () => null
+    router: (): null => null
   };
 
   constructor(props: PropsType) {
@@ -59,43 +64,47 @@ export class NavigationComponent extends React.Component<PropsType, NavigationSt
     };
   }
 
-  setControlledState = event => {
+  setControlledState = (event: Event): void => {
     if ('navCollapsed' in event) {
       this.props.setNavCollapsed(this.props.navCollapsed);
     }
   };
 
-  goTotracing() {
+  goTotracing = (): void => {
     window.open(this.props.tracingUrl, '_blank');
-  }
+  };
 
-  componentDidMount() {
+  componentDidMount = (): void => {
     let pageTitle = serverConfig.installationTag ? serverConfig.installationTag : 'Kiali';
     if (homeCluster?.name) {
       pageTitle += ` [${homeCluster?.name}]`;
     }
 
     document.title = pageTitle;
-  }
-
-  isGraph = () => {
-    return this.props.location.pathname.startsWith('/graph') || this.props.location.pathname.startsWith('/graphpf');
   };
 
-  onNavToggleDesktop = () => {
+  isGraph = (): boolean => {
+    return (
+      this.props.location.pathname.startsWith('/graph') ||
+      this.props.location.pathname.startsWith('/graphpf') ||
+      this.props.location.pathname.startsWith('/mesh')
+    );
+  };
+
+  onNavToggleDesktop = (): void => {
     this.setState({
       isNavOpenDesktop: !this.state.isNavOpenDesktop
     });
     this.props.setNavCollapsed(!this.props.navCollapsed);
   };
 
-  onNavToggleMobile = () => {
+  onNavToggleMobile = (): void => {
     this.setState({
       isNavOpenMobile: !this.state.isNavOpenMobile
     });
   };
 
-  onPageResize = ({ mobileView, windowSize }) => {
+  onPageResize = ({ mobileView, windowSize }: { mobileView: boolean; windowSize: number }): void => {
     let ismobile = mobileView;
     if (windowSize < 1000) {
       ismobile = true;
@@ -105,7 +114,7 @@ export class NavigationComponent extends React.Component<PropsType, NavigationSt
     });
   };
 
-  render() {
+  render = (): React.ReactNode => {
     const { isNavOpenDesktop, isNavOpenMobile, isMobileView } = this.state;
     const isNavOpen = isMobileView ? isNavOpenMobile : isNavOpenDesktop || !this.props.navCollapsed;
 
@@ -154,16 +163,16 @@ export class NavigationComponent extends React.Component<PropsType, NavigationSt
         </PageSection>
       </Page>
     );
-  }
+  };
 }
 
-const mapStateToProps = (state: KialiAppState) => ({
+const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   navCollapsed: state.userSettings.interface.navCollapse,
   tracingUrl: state.tracingState.info && state.tracingState.info.url ? state.tracingState.info.url : undefined,
   externalServices: state.statusState.externalServices
 });
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => ({
+const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => ({
   setNavCollapsed: (collapse: boolean) => dispatch(UserSettingsThunkActions.setNavCollapsed(collapse))
 });
 

--- a/frontend/src/pages/Graph/SummaryPanelStyle.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelStyle.tsx
@@ -2,7 +2,7 @@ import { PFColors } from 'components/Pf/PfColors';
 import { kialiStyle } from 'styles/StyleUtils';
 
 export const panelStyle = kialiStyle({
-  marginBottom: '23px',
+  marginBottom: '1.5rem',
   border: `1px solid ${PFColors.BorderColor100}`,
   borderRadius: '1px',
   '-webkit-box-shadow': '0 1px 1px rgba(0, 0, 0, 0.05)',
@@ -10,15 +10,14 @@ export const panelStyle = kialiStyle({
 });
 
 export const panelHeadingStyle = kialiStyle({
-  padding: '10px 15px',
-  borderBottom: '1px solid transparent',
+  padding: '0.5rem 1rem',
+  borderBottom: `1px solid ${PFColors.BorderColor100}`,
   borderTopLeftRadius: 0,
-  borderTopRightRadius: 0,
-  borderColor: PFColors.BorderColor100
+  borderTopRightRadius: 0
 });
 
 export const panelBodyStyle = kialiStyle({
-  padding: '15px',
+  padding: '1rem',
   $nest: {
     '&:after, &:before': {
       display: 'table',
@@ -27,6 +26,10 @@ export const panelBodyStyle = kialiStyle({
 
     '&:after': {
       clear: 'both'
+    },
+
+    '& pre': {
+      whiteSpace: 'pre-wrap'
     }
   }
 });

--- a/frontend/src/pages/Mesh/target/TargetPanel.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanel.tsx
@@ -8,7 +8,7 @@ import { FocusNode } from 'pages/GraphPF/GraphPF';
 import { classes } from 'typestyle';
 import { PFColors } from 'components/Pf/PfColors';
 import { MeshInfraType, MeshTarget, MeshType } from 'types/Mesh';
-import { TargetPanelCommonProps, targetPanel } from './TargetPanelCommon';
+import { TargetPanelCommonProps, targetPanelStyle } from './TargetPanelCommon';
 import { MeshTourStops } from '../MeshHelpTour';
 import { BoxByType } from 'types/Graph';
 import { ElementModel, GraphElement } from '@patternfly/react-topology';
@@ -26,6 +26,7 @@ type TargetPanelState = {
 };
 
 type ReduxProps = {
+  kiosk: string;
   meshStatus: string;
   minTLS: string;
 };
@@ -47,7 +48,7 @@ const expandedStyle = kialiStyle({ height: '100%' });
 
 const collapsedStyle = kialiStyle({
   $nest: {
-    ['& > .' + targetPanel]: {
+    [`& > .${targetPanelStyle}`]: {
       display: 'none'
     }
   }
@@ -81,7 +82,7 @@ class TargetPanelComponent extends React.Component<TargetPanelProps, TargetPanel
     }
   }
 
-  render() {
+  render(): React.ReactNode {
     if (!this.props.isPageVisible || !this.props.target.elem) {
       return null;
     }
@@ -112,7 +113,7 @@ class TargetPanelComponent extends React.Component<TargetPanelProps, TargetPanel
     );
   }
 
-  private getTargetPanel = (target: MeshTarget): React.ReactFragment => {
+  private getTargetPanel = (target: MeshTarget): React.ReactNode => {
     const targetType = target.type as MeshType;
 
     switch (targetType) {
@@ -203,14 +204,14 @@ class TargetPanelComponent extends React.Component<TargetPanelProps, TargetPanel
     }
   };
 
-  private togglePanel = () => {
+  private togglePanel = (): void => {
     this.setState((state: TargetPanelState) => ({
       isCollapsed: !state.isCollapsed
     }));
   };
 }
 
-const mapStateToProps = (state: KialiAppState) => ({
+const mapStateToProps = (state: KialiAppState): ReduxProps => ({
   kiosk: state.globalState.kiosk,
   meshStatus: meshWideMTLSStatusSelector(state),
   minTLS: minTLSVersionSelector(state)

--- a/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
@@ -4,15 +4,7 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { getKialiTheme } from 'utils/ThemeUtils';
-import {
-  TargetPanelCommonProps,
-  shouldRefreshData,
-  targetPanel,
-  targetPanelBody,
-  targetPanelBorder,
-  targetPanelHeading,
-  targetPanelWidth
-} from './TargetPanelCommon';
+import { TargetPanelCommonProps, shouldRefreshData, targetPanelStyle, targetPanelWidth } from './TargetPanelCommon';
 import { kialiIconDark, kialiIconLight } from 'config';
 import { KialiInstance, MeshNodeData, isExternal } from 'types/Mesh';
 import { I18N_NAMESPACE, Theme } from 'types/Common';
@@ -26,6 +18,7 @@ import { classes } from 'typestyle';
 import { descendents } from '../MeshElems';
 import { renderNodeHeader } from './TargetPanelNode';
 import { WithTranslation, withTranslation } from 'react-i18next';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 
 type TargetPanelClusterProps = WithTranslation & TargetPanelCommonProps;
 
@@ -73,21 +66,21 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
       : null;
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.load();
   }
 
-  componentDidUpdate(prevProps: TargetPanelClusterProps) {
+  componentDidUpdate(prevProps: TargetPanelClusterProps): void {
     if (shouldRefreshData(prevProps, this.props)) {
       this.load();
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.promises.cancelAll();
   }
 
-  render() {
+  render(): React.ReactNode {
     if (this.state.loading || !this.state.clusterNode) {
       return null;
     }
@@ -101,8 +94,8 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
     const version = data.version;
 
     return (
-      <div id="target-panel-cluster" className={classes(targetPanelBorder, targetPanel)}>
-        <div id="target-panel-cluster-heading" className={targetPanelHeading}>
+      <div id="target-panel-cluster" className={classes(panelStyle, targetPanelStyle)}>
+        <div id="target-panel-cluster-heading" className={panelHeadingStyle}>
           {clusterData.isKialiHome && (
             <Tooltip content={this.props.t('Kiali home cluster')}>
               <KialiIcon.Star />
@@ -112,7 +105,7 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
           {clusterData.name}
         </div>
         {isExternal(data.cluster) ? (
-          <div className={targetPanelBody}>
+          <div className={panelBodyStyle}>
             {descendents(this.state.clusterNode)
               .sort((n1, n2) => {
                 const name1 = (n1.getData() as MeshNodeData).infraName.toLowerCase();
@@ -124,7 +117,7 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
               })}
           </div>
         ) : (
-          <div className={targetPanelBody}>
+          <div className={panelBodyStyle}>
             {clusterData.accessible && this.renderKialiLinks(clusterData.kialiInstances)}
             {version && (
               <>
@@ -174,7 +167,7 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
 
   private renderKialiLinks = (kialiInstances: KialiInstance[]): React.ReactNode => {
     const kialiIcon = getKialiTheme() === Theme.DARK ? kialiIconDark : kialiIconLight;
-    return kialiInstances.map(instance => {
+    return kialiInstances?.map(instance => {
       if (instance.url.length !== 0) {
         return (
           <span>

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -20,54 +20,20 @@ export interface TargetPanelCommonProps {
 
 export const targetPanelWidth = '35rem';
 
-export const targetPanel = kialiStyle({
+export const targetPanelStyle = kialiStyle({
   fontSize: 'var(--graph-side-panel--font-size)',
   height: '100%',
   margin: 0,
   minWidth: targetPanelWidth,
-  overflowY: 'scroll',
+  overflowY: 'auto',
   padding: 0,
   position: 'relative',
   width: targetPanelWidth
 });
 
-export const targetPanelBody = kialiStyle({
-  padding: '15px',
-  $nest: {
-    '&:after, &:before': {
-      display: 'table',
-      content: ' '
-    },
-
-    '&:after': {
-      clear: 'both'
-    }
-  }
-});
-
-export const targetPanelBorder = kialiStyle({
-  marginBottom: '23px',
-  border: `1px solid ${PFColors.BorderColor100}`,
-  borderRadius: '1px',
-  '-webkit-box-shadow': '0 1px 1px rgba(0, 0, 0, 0.05)',
-  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.05)'
-});
-
 export const targetPanelFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'
 };
-
-export const targetPanelHeading = kialiStyle({
-  padding: '10px 15px',
-  borderBottom: '1px solid transparent',
-  borderTopLeftRadius: 0,
-  borderTopRightRadius: 0,
-  borderColor: PFColors.BorderColor100
-});
-
-export const TargetPanelTabs = kialiStyle({
-  padding: '0.5rem 1rem 0 1rem'
-});
 
 export const targetPanelTitle = kialiStyle({
   fontWeight: 'bolder',
@@ -83,12 +49,10 @@ const healthStatusStyle = kialiStyle({
 const hrStyle = kialiStyle({
   border: 0,
   borderTop: `1px solid ${PFColors.BorderColor100}`,
-  margin: '1.0rem 0'
+  margin: '1rem 0'
 });
 
-export const targetPanelHR = (): React.ReactNode => {
-  return <hr className={hrStyle} />;
-};
+export const targetPanelHR = <hr className={hrStyle} />;
 
 export const shouldRefreshData = (prevProps: TargetPanelCommonProps, nextProps: TargetPanelCommonProps): boolean => {
   return (

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
@@ -5,13 +5,11 @@ import {
   TargetPanelCommonProps,
   getHealthStatus,
   shouldRefreshData,
-  targetPanel,
-  targetPanelBody,
-  targetPanelBorder,
-  targetPanelHR
+  targetPanelHR,
+  targetPanelStyle
 } from './TargetPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
-import { Card, CardBody, CardHeader, Title, TitleSizes } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { serverConfig } from 'config';
 import { CanaryUpgradeStatus, OutboundTrafficPolicy } from 'types/IstioObjects';
 import { NamespaceInfo, NamespaceStatus } from 'types/NamespaceInfo';
@@ -35,7 +33,7 @@ import * as FilterHelper from '../../../components/FilterList/FilterHelper';
 import { NodeData } from '../MeshElems';
 import { ControlPlaneMetricsMap, Metric } from 'types/Metrics';
 import { classes } from 'typestyle';
-import { panelHeadingStyle } from 'pages/Graph/SummaryPanelStyle';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { MeshMTLSStatus } from 'components/MTls/MeshMTLSStatus';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { I18N_NAMESPACE } from 'types/Common';
@@ -75,12 +73,6 @@ const defaultState: TargetPanelControlPlaneState = {
 
 // TODO: Should these remain fixed values?
 const direction: DirectionType = 'outbound';
-
-const cardGridStyle = kialiStyle({
-  marginBottom: '0.5rem',
-  marginTop: 0,
-  textAlign: 'center'
-});
 
 const nodeStyle = kialiStyle({
   alignItems: 'center',
@@ -137,73 +129,66 @@ class TargetPanelControlPlaneComponent extends React.Component<
     const data = this.state.controlPlaneNode?.getData() as NodeData;
 
     return (
-      <div id="target-panel-control-plane" className={classes(targetPanelBorder, targetPanel)}>
-        <Card
-          isCompact={true}
-          className={cardGridStyle}
-          data-test={`${data.infraName}-mesh-target`}
-          style={!this.props.istioAPIEnabled && !this.hasCanaryUpgradeConfigured() ? { height: '96%' } : {}}
-        >
-          <CardHeader className={panelHeadingStyle}>
-            <Title headingLevel="h5" size={TitleSizes.lg}>
-              <span className={nodeStyle}>
-                <PFBadge badge={PFBadges.Istio} size="global" />
-                {data.infraName}
-                {getHealthStatus(data, this.props.t)}
-              </span>
-            </Title>
+      <div
+        id="target-panel-control-plane"
+        data-test={`${data.infraName}-mesh-target`}
+        className={classes(panelStyle, targetPanelStyle)}
+      >
+        <div className={panelHeadingStyle}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
             <span className={nodeStyle}>
-              <PFBadge badge={PFBadges.Namespace} size="sm" />
-              {data.namespace}
+              <PFBadge badge={PFBadges.Istio} size="global" />
+              {data.infraName}
+              {getHealthStatus(data, this.props.t)}
             </span>
-            <span className={nodeStyle}>
-              <PFBadge badge={PFBadges.Cluster} size="sm" />
-              {data.cluster}
-            </span>
-          </CardHeader>
-          <CardBody>
-            <div className={targetPanelBody}>
-              {data.version && (
-                <div style={{ textAlign: 'left' }}>
-                  {`Version: `}
-                  {data.version}
-                  <br />
-                </div>
-              )}
-              <div style={{ textAlign: 'left' }}>
-                <div>
-                  <MeshMTLSStatus />
-                </div>
-              </div>
-
-              <ControlPlaneNamespaceStatus
-                outboundTrafficPolicy={this.state.outboundPolicyMode}
-                namespace={nsInfo}
-              ></ControlPlaneNamespaceStatus>
-
-              <TLSInfo
-                certificatesInformationIndicators={
-                  serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled
-                }
-                version={this.props.minTLS}
-              ></TLSInfo>
-
-              {!isRemoteCluster(nsInfo.annotations) && (
-                <div>
-                  {targetPanelHR()}
-                  {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
-                    <div>
-                      {targetPanelHR}
-                      <CanaryUpgradeProgress canaryUpgradeStatus={this.state.canaryUpgradeStatus} />
-                    </div>
-                  )}
-                  <div>{this.props.istioAPIEnabled && <div>{this.renderCharts()}</div>}</div>
-                </div>
-              )}
+          </Title>
+          <span className={nodeStyle}>
+            <PFBadge badge={PFBadges.Namespace} size="sm" />
+            {data.namespace}
+          </span>
+          <span className={nodeStyle}>
+            <PFBadge badge={PFBadges.Cluster} size="sm" />
+            {data.cluster}
+          </span>
+        </div>
+        <div className={panelBodyStyle}>
+          {data.version && (
+            <div style={{ textAlign: 'left' }}>
+              {`Version: `}
+              {data.version}
+              <br />
             </div>
-          </CardBody>
-        </Card>
-        <div className={targetPanelBody}>
+          )}
+          <div style={{ textAlign: 'left' }}>
+            <div>
+              <MeshMTLSStatus />
+            </div>
+          </div>
+
+          <ControlPlaneNamespaceStatus
+            outboundTrafficPolicy={this.state.outboundPolicyMode}
+            namespace={nsInfo}
+          ></ControlPlaneNamespaceStatus>
+
+          <TLSInfo
+            certificatesInformationIndicators={serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled}
+            version={this.props.minTLS}
+          ></TLSInfo>
+
+          {!isRemoteCluster(nsInfo.annotations) && (
+            <div>
+              {targetPanelHR}
+              {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
+                <div>
+                  {targetPanelHR}
+                  <CanaryUpgradeProgress canaryUpgradeStatus={this.state.canaryUpgradeStatus} />
+                </div>
+              )}
+              <div>{this.props.istioAPIEnabled && <div>{this.renderCharts()}</div>}</div>
+            </div>
+          )}
+
+          {targetPanelHR}
           <pre>{JSON.stringify(data.infraData, null, 2)}</pre>
         </div>
       </div>
@@ -212,20 +197,14 @@ class TargetPanelControlPlaneComponent extends React.Component<
 
   private getLoading = (): React.ReactNode => {
     return (
-      <div className={classes(targetPanelBorder, targetPanel)}>
-        <Card
-          isCompact={true}
-          className={cardGridStyle}
-          style={!this.props.istioAPIEnabled && !this.hasCanaryUpgradeConfigured() ? { height: '96%' } : {}}
-        >
-          <CardHeader className={panelHeadingStyle}>
-            <Title headingLevel="h5" size={TitleSizes.lg}>
-              <span className={nodeStyle}>
-                <span>Loading...</span>
-              </span>
-            </Title>
-          </CardHeader>
-        </Card>
+      <div className={classes(panelStyle, targetPanelStyle)}>
+        <div className={panelHeadingStyle}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
+            <span className={nodeStyle}>
+              <span>Loading...</span>
+            </span>
+          </Title>
+        </div>
       </div>
     );
   };
@@ -444,7 +423,7 @@ class TargetPanelControlPlaneComponent extends React.Component<
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
 
-  private renderCharts(): JSX.Element {
+  private renderCharts(): React.ReactNode {
     if (this.state.status) {
       const data = this.state.controlPlaneNode!.getData() as NodeData;
       return (

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlane.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Node, NodeModel } from '@patternfly/react-topology';
-import { TargetPanelCommonProps, targetPanel, targetPanelBody, targetPanelHeading } from './TargetPanelCommon';
+import { TargetPanelCommonProps, targetPanelHR, targetPanelStyle } from './TargetPanelCommon';
 import { classes } from 'typestyle';
 import { MeshNodeData } from 'types/Mesh';
-import { panelStyle } from 'pages/Graph/SummaryPanelStyle';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { kialiStyle } from 'styles/StyleUtils';
 import { Title, TitleSizes } from '@patternfly/react-core';
@@ -14,14 +14,14 @@ import { serverConfig } from 'config';
 
 type TargetPanelDataPlaneState = {
   expanded: string[];
-  node?: Node<NodeModel, any>;
   loading: boolean;
+  node?: Node<NodeModel, any>;
 };
 
 const defaultState: TargetPanelDataPlaneState = {
   expanded: [],
-  node: undefined,
-  loading: false
+  loading: false,
+  node: undefined
 };
 
 const nodeStyle = kialiStyle({
@@ -37,7 +37,7 @@ export class TargetPanelDataPlane extends React.Component<TargetPanelCommonProps
     this.state = { ...defaultState, node: dataPlaneNode };
   }
 
-  render() {
+  render(): React.ReactNode {
     if (!this.state.node) {
       return null;
     }
@@ -46,9 +46,9 @@ export class TargetPanelDataPlane extends React.Component<TargetPanelCommonProps
     const data = node.getData() as MeshNodeData;
 
     return (
-      <div id="target-panel-data-plane" className={classes(panelStyle, targetPanel)}>
-        <div className={targetPanelHeading}>{this.renderNodeHeader(data)}</div>
-        <div className={targetPanelBody}>
+      <div id="target-panel-data-plane" className={classes(panelStyle, targetPanelStyle)}>
+        <div className={panelHeadingStyle}>{this.renderNodeHeader(data)}</div>
+        <div className={panelBodyStyle}>
           <Table aria-label="dataplane-table" variant="compact">
             <Thead>
               <Tr>
@@ -86,6 +86,7 @@ export class TargetPanelDataPlane extends React.Component<TargetPanelCommonProps
                             targetNamespace={ns.name}
                             updateTime={this.props.updateTime}
                           />
+                          {targetPanelHR}
                           <pre>
                             {JSON.stringify(
                               data.infraData.find(id => id.name === ns.name),

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { kialiStyle } from 'styles/StyleUtils';
-import {
-  TargetPanelCommonProps,
-  targetPanel,
-  targetPanelBody,
-  targetPanelBorder,
-  targetPanelHR
-} from './TargetPanelCommon';
+import { TargetPanelCommonProps, targetPanelHR } from './TargetPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { Card, CardBody, CardHeader, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Paths, serverConfig } from 'config';
@@ -35,8 +29,7 @@ import { switchType } from 'pages/Overview/OverviewHelper';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
 import { TLSStatus } from 'types/TLSStatus';
 import * as FilterHelper from '../../../components/FilterList/FilterHelper';
-import { classes } from 'typestyle';
-import { panelHeadingStyle } from 'pages/Graph/SummaryPanelStyle';
+import { panelBodyStyle, panelHeadingStyle } from 'pages/Graph/SummaryPanelStyle';
 import { Metric } from 'types/Metrics';
 
 type TargetPanelDataPlaneNamespaceProps = Omit<TargetPanelCommonProps, 'target'> & {
@@ -77,7 +70,8 @@ const healthType: OverviewType = 'app';
 const cardGridStyle = kialiStyle({
   textAlign: 'center',
   marginTop: 0,
-  marginBottom: '0.5rem'
+  marginBottom: '-0.5rem',
+  boxShadow: 'none'
 });
 
 const namespaceNameStyle = kialiStyle({
@@ -87,12 +81,6 @@ const namespaceNameStyle = kialiStyle({
   verticalAlign: 'middle',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis'
-});
-
-const panel = kialiStyle({
-  fontSize: 'var(--graph-side-panel--font-size)',
-  margin: 0,
-  padding: 0
 });
 
 export class TargetPanelDataPlaneNamespace extends React.Component<
@@ -132,66 +120,60 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     );
 
     return (
-      <div className={classes(targetPanelBorder, panel)}>
-        <Card isCompact={true} className={cardGridStyle} data-test={`${ns}-mesh-target`} style={{ height: '96%' }}>
-          <CardHeader
-            className={panelHeadingStyle}
-            actions={{ actions: <>{namespaceActions}</>, hasNoOffset: false, className: undefined }}
-          >
-            <Title headingLevel="h5" size={TitleSizes.lg}>
-              <span className={namespaceNameStyle}>
-                <span>
-                  <PFBadge badge={PFBadges.Namespace} />
-                  {ns}
-                </span>
-                {this.renderNamespaceBadges(nsInfo, true)}
+      <Card isCompact={true} className={cardGridStyle} data-test={`${ns}-mesh-target`}>
+        <CardHeader
+          className={panelHeadingStyle}
+          actions={{ actions: <>{namespaceActions}</>, hasNoOffset: false, className: undefined }}
+        >
+          <Title headingLevel="h5" size={TitleSizes.lg}>
+            <span className={namespaceNameStyle}>
+              <span>
+                <PFBadge badge={PFBadges.Namespace} />
+                {ns}
               </span>
-            </Title>
-            <div style={{ textAlign: 'left', paddingBottom: 3 }}>
-              <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />
-              {nsInfo.cluster}
-            </div>
-          </CardHeader>
-          <CardBody>
-            <div className={targetPanelBody}>
-              {this.renderLabels(nsInfo)}
+              {this.renderNamespaceBadges(nsInfo, true)}
+            </span>
+          </Title>
+          <div style={{ textAlign: 'left', paddingBottom: 3 }}>
+            <PFBadge badge={PFBadges.Cluster} position={TooltipPosition.right} />
+            {nsInfo.cluster}
+          </div>
+        </CardHeader>
+        <CardBody className={panelBodyStyle}>
+          {this.renderLabels(nsInfo)}
 
-              <div style={{ textAlign: 'left' }}>
-                <div style={{ display: 'inline-block', width: '125px' }}>Istio config</div>
+          <div style={{ textAlign: 'left' }}>
+            <div style={{ display: 'inline-block', width: '125px' }}>Istio config</div>
 
-                {nsInfo.tlsStatus && (
-                  <span>
-                    <NamespaceMTLSStatus status={nsInfo.tlsStatus.status} />
-                  </span>
-                )}
-                {this.props.istioAPIEnabled ? this.renderIstioConfigStatus(nsInfo) : 'N/A'}
-              </div>
+            {nsInfo.tlsStatus && (
+              <span>
+                <NamespaceMTLSStatus status={nsInfo.tlsStatus.status} />
+              </span>
+            )}
+            {this.props.istioAPIEnabled ? this.renderIstioConfigStatus(nsInfo) : 'N/A'}
+          </div>
 
-              {this.renderStatus()}
+          {this.renderStatus()}
 
-              {targetPanelHR()}
-              {this.renderCharts('inbound')}
-              {this.renderCharts('outbound')}
-            </div>
-          </CardBody>
-        </Card>
-      </div>
+          {targetPanelHR}
+          {this.renderCharts('inbound')}
+          {this.renderCharts('outbound')}
+        </CardBody>
+      </Card>
     );
   }
 
   private getLoading = (): React.ReactNode => {
     return (
-      <div className={classes(targetPanelBorder, targetPanel)}>
-        <Card isCompact={true} className={cardGridStyle} style={{ height: '96%' }}>
-          <CardHeader className={panelHeadingStyle}>
-            <Title headingLevel="h5" size={TitleSizes.lg}>
-              <span className={namespaceNameStyle}>
-                <span>Loading...</span>
-              </span>
-            </Title>
-          </CardHeader>
-        </Card>
-      </div>
+      <Card isCompact={true} className={cardGridStyle}>
+        <CardHeader className={panelHeadingStyle}>
+          <Title headingLevel="h5" size={TitleSizes.lg}>
+            <span className={namespaceNameStyle}>
+              <span>Loading...</span>
+            </span>
+          </Title>
+        </CardHeader>
+      </Card>
     );
   };
 
@@ -269,7 +251,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     return namespaceActions;
   };
 
-  private renderNamespaceBadges(ns: NamespaceInfo, tooltip: boolean): JSX.Element {
+  private renderNamespaceBadges(ns: NamespaceInfo, tooltip: boolean): React.ReactNode {
     return (
       <>
         {serverConfig.ambientEnabled && ns.labels && ns.isAmbient && (
@@ -279,7 +261,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     );
   }
 
-  private renderLabels(ns: NamespaceInfo): JSX.Element {
+  private renderLabels(ns: NamespaceInfo): React.ReactNode {
     const labelsLength = ns.labels ? `${Object.entries(ns.labels).length}` : 'No';
 
     const labelContent = ns.labels ? (
@@ -311,7 +293,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     return labelContent;
   }
 
-  private renderIstioConfigStatus(ns: NamespaceInfo): JSX.Element {
+  private renderIstioConfigStatus(ns: NamespaceInfo): React.ReactNode {
     let validations: ValidationStatus = { errors: 0, namespace: ns.name, objectCount: 0, warnings: 0 };
 
     if (!!ns.validations) {
@@ -449,7 +431,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
 
-  private renderCharts(direction: DirectionType): JSX.Element {
+  private renderCharts(direction: DirectionType): React.ReactNode {
     if (this.state.status) {
       const namespace = this.props.targetNamespace;
       return (
@@ -469,7 +451,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
     return <div style={{ height: '70px' }} />;
   }
 
-  private renderStatus(): JSX.Element {
+  private renderStatus(): React.ReactNode {
     const targetPage = switchType(healthType, Paths.APPLICATIONS, Paths.SERVICES, Paths.WORKLOADS);
     const namespace = this.props.targetNamespace;
     const status = this.state.status;

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { Visualization } from '@patternfly/react-topology';
-import {
-  TargetPanelCommonProps,
-  getTitle,
-  targetPanel,
-  targetPanelBorder,
-  targetPanelHeading
-} from './TargetPanelCommon';
+import { GraphElement, Visualization } from '@patternfly/react-topology';
+import { TargetPanelCommonProps, getTitle, targetPanelStyle } from './TargetPanelCommon';
 import { classes } from 'typestyle';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
+import { elems, selectAnd } from '../MeshElems';
+import { MeshAttr, MeshInfraType } from 'types/Mesh';
+import { renderNodeHeader } from './TargetPanelNode';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { I18N_NAMESPACE } from 'types/Common';
 
 type TargetPanelMeshState = {
   loading: boolean;
@@ -19,38 +19,55 @@ const defaultState: TargetPanelMeshState = {
   loading: false
 };
 
-export class TargetPanelMesh extends React.Component<TargetPanelCommonProps, TargetPanelMeshState> {
-  constructor(props: TargetPanelCommonProps) {
+type TargetPanelMeshProps = WithTranslation & TargetPanelCommonProps;
+
+class TargetPanelMeshComponent extends React.Component<TargetPanelMeshProps, TargetPanelMeshState> {
+  constructor(props: TargetPanelMeshProps) {
     super(props);
 
     this.state = { ...defaultState };
   }
 
-  static getDerivedStateFromProps(props: TargetPanelCommonProps, state: TargetPanelMeshState) {
+  static getDerivedStateFromProps: React.GetDerivedStateFromProps<TargetPanelMeshProps, TargetPanelMeshState> = (
+    props: TargetPanelCommonProps,
+    state: TargetPanelMeshState
+  ) => {
     // if the target (i.e. mesh) has changed, then init the state and set to loading. The loading
     // will actually be kicked off after the render (in componentDidMount/Update).
     return props.target.elem !== state.mesh ? { graph: props.target.elem, loading: true } : null;
-  }
+  };
 
-  componentDidMount() {}
-
-  componentDidUpdate(_prevProps: TargetPanelCommonProps) {}
-
-  componentWillUnmount() {}
-
-  render() {
+  render(): React.ReactNode {
     const controller = this.props.target.elem as Visualization;
 
     if (!controller) {
       return null;
     }
 
+    const { nodes } = elems(controller);
+
+    const infraNodes = selectAnd(nodes, [
+      { prop: MeshAttr.infraType, op: '!=', val: MeshInfraType.CLUSTER },
+      { prop: MeshAttr.infraType, op: '!=', val: MeshInfraType.NAMESPACE },
+      { prop: MeshAttr.infraType, op: '!=', val: MeshInfraType.DATAPLANE },
+      { prop: MeshAttr.infraType, op: '!=', val: '' }
+    ]);
+
     return (
-      <div id="target-panel-mesh" className={classes(targetPanelBorder, targetPanel)}>
-        <div id="target-panel-mesh-heading" className={targetPanelHeading}>
+      <div id="target-panel-mesh" className={classes(panelStyle, targetPanelStyle)}>
+        <div id="target-panel-mesh-heading" className={panelHeadingStyle}>
           {getTitle(`Mesh Name: ${controller.getGraph().getData().meshData.name}`)}
+        </div>
+        <div id="target-panel-mesh-body" className={panelBodyStyle}>
+          {this.renderMeshSummary(infraNodes)}
         </div>
       </div>
     );
   }
+
+  private renderMeshSummary = (infraNodes: GraphElement[]): React.ReactNode => (
+    <>{infraNodes.map(node => renderNodeHeader(node.getData(), this.props.t, true))}</>
+  );
 }
+
+export const TargetPanelMesh = withTranslation(I18N_NAMESPACE)(TargetPanelMeshComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { ElementModel, GraphElement, Node, NodeModel } from '@patternfly/react-topology';
 import { kialiStyle } from 'styles/StyleUtils';
-import {
-  TargetPanelCommonProps,
-  shouldRefreshData,
-  targetPanel,
-  targetPanelBody,
-  targetPanelBorder,
-  targetPanelHR
-} from './TargetPanelCommon';
+import { TargetPanelCommonProps, shouldRefreshData, targetPanelHR, targetPanelStyle } from './TargetPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { Card, CardBody, CardHeader, Label, Title, TitleSizes, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Paths, serverConfig } from 'config';
@@ -45,7 +38,7 @@ import { TLSStatus } from 'types/TLSStatus';
 import * as FilterHelper from '../../../components/FilterList/FilterHelper';
 import { ControlPlaneMetricsMap, Metric } from 'types/Metrics';
 import { classes } from 'typestyle';
-import { panelHeadingStyle } from 'pages/Graph/SummaryPanelStyle';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 
 type TargetPanelNamespaceProps = TargetPanelCommonProps;
 
@@ -85,7 +78,8 @@ const direction: DirectionType = 'outbound';
 const cardGridStyle = kialiStyle({
   textAlign: 'center',
   marginTop: 0,
-  marginBottom: '0.5rem'
+  marginBottom: '0.5rem',
+  boxShadow: 'none'
 });
 
 const namespaceNameStyle = kialiStyle({
@@ -157,8 +151,9 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     );
 
     return (
-      <div id="target-panel-namespace" className={classes(targetPanelBorder, targetPanel)}>
+      <div className={classes(panelStyle, targetPanelStyle)}>
         <Card
+          id="target-panel-namespace"
           isCompact={true}
           className={cardGridStyle}
           data-test={`${ns}-mesh-target`}
@@ -182,9 +177,9 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
               {nsInfo.cluster}
             </div>
           </CardHeader>
-          <CardBody>
+          <CardBody className={panelBodyStyle}>
             {isControlPlane && !isRemoteCluster(nsInfo.annotations) && (
-              <div className={targetPanelBody}>
+              <>
                 {this.renderLabels(nsInfo)}
 
                 <div style={{ textAlign: 'left' }}>
@@ -199,7 +194,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
                 {isControlPlane && (
                   <div>
-                    {targetPanelHR()}
+                    {targetPanelHR}
                     {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
                       <div>
                         {targetPanelHR}
@@ -209,11 +204,11 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
                     <div>{this.props.istioAPIEnabled && <div>{this.renderCharts()}</div>}</div>
                   </div>
                 )}
-              </div>
+              </>
             )}
 
             {isControlPlane && isRemoteCluster(nsInfo.annotations) && (
-              <div className={targetPanelBody}>
+              <>
                 {this.renderLabels(nsInfo)}
 
                 <div style={{ textAlign: 'left' }}>
@@ -231,11 +226,11 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
                 {this.renderStatus()}
 
                 <div style={{ height: '110px' }} />
-              </div>
+              </>
             )}
 
             {!isControlPlane && (
-              <div className={targetPanelBody}>
+              <>
                 {this.renderLabels(nsInfo)}
 
                 <div style={{ textAlign: 'left' }}>
@@ -251,9 +246,9 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
                 {this.renderStatus()}
 
-                {targetPanelHR()}
+                {targetPanelHR}
                 {this.renderCharts()}
-              </div>
+              </>
             )}
           </CardBody>
         </Card>
@@ -263,7 +258,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
   private getLoading = (): React.ReactNode => {
     return (
-      <div className={classes(targetPanelBorder, targetPanel)}>
+      <div className={classes(panelStyle, targetPanelStyle)}>
         <Card
           isCompact={true}
           className={cardGridStyle}
@@ -579,7 +574,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     return namespaceActions;
   };
 
-  private renderNamespaceBadges(ns: NamespaceInfo, tooltip: boolean): JSX.Element {
+  private renderNamespaceBadges(ns: NamespaceInfo, tooltip: boolean): React.ReactNode {
     const isControlPlane = this.isControlPlane();
     return (
       <>
@@ -616,7 +611,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     );
   }
 
-  private renderLabels(ns: NamespaceInfo): JSX.Element {
+  private renderLabels(ns: NamespaceInfo): React.ReactNode {
     const labelsLength = ns.labels ? `${Object.entries(ns.labels).length}` : 'No';
 
     const labelContent = ns.labels ? (
@@ -648,7 +643,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     return labelContent;
   }
 
-  private renderIstioConfigStatus(ns: NamespaceInfo): JSX.Element {
+  private renderIstioConfigStatus(ns: NamespaceInfo): React.ReactNode {
     let validations: ValidationStatus = { errors: 0, namespace: ns.name, objectCount: 0, warnings: 0 };
 
     if (!!ns.validations) {
@@ -840,7 +835,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     FilterHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
 
-  private renderCharts(): JSX.Element {
+  private renderCharts(): React.ReactNode {
     if (this.state.status) {
       const namespace = this.state.targetNamespace!;
       return (
@@ -861,7 +856,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
     return <div style={{ height: '70px' }} />;
   }
 
-  private renderStatus(): JSX.Element {
+  private renderStatus(): React.ReactNode {
     const targetPage = switchType(healthType, Paths.APPLICATIONS, Paths.SERVICES, Paths.WORKLOADS);
     const namespace = this.state.targetNamespace!;
     const status = this.state.status;

--- a/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
 import { Node, NodeModel } from '@patternfly/react-topology';
 import { kialiStyle } from 'styles/StyleUtils';
-import {
-  TargetPanelCommonProps,
-  getHealthStatus,
-  targetPanel,
-  targetPanelBody,
-  targetPanelHeading
-} from './TargetPanelCommon';
+import { TargetPanelCommonProps, getHealthStatus, targetPanelStyle } from './TargetPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { MeshInfraType, MeshNodeData, isExternal } from 'types/Mesh';
 import { classes } from 'typestyle';
-import { panelStyle } from 'pages/Graph/SummaryPanelStyle';
+import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { Title, TitleSizes } from '@patternfly/react-core';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { I18N_NAMESPACE } from 'types/Common';
@@ -58,8 +52,12 @@ export function renderNodeHeader(
     case MeshInfraType.TRACE_STORE:
       pfBadge = PFBadges.TraceStore;
       break;
+    case MeshInfraType.ISTIOD:
+      pfBadge = PFBadges.Istio;
+      break;
     default:
       console.warn(`MeshElems: Unexpected infraType [${data.infraType}] `);
+      pfBadge = PFBadges.Unknown;
   }
 
   return (
@@ -68,7 +66,7 @@ export function renderNodeHeader(
         <span className={nodeStyle}>
           <PFBadge badge={pfBadge} size="global" />
           {data.infraName}
-          {!nameOnly && getHealthStatus(data, t)}
+          {getHealthStatus(data, t)}
         </span>
       </Title>
       {!nameOnly && (
@@ -118,9 +116,9 @@ class TargetPanelNodeComponent extends React.Component<TargetPanelNodeProps, Tar
     const data = node.getData() as MeshNodeData;
 
     return (
-      <div id="target-panel-node" className={classes(panelStyle, targetPanel)}>
-        <div className={targetPanelHeading}>{renderNodeHeader(data, this.props.t, isExternal(data.cluster))}</div>
-        <div className={targetPanelBody}>
+      <div id="target-panel-node" className={classes(panelStyle, targetPanelStyle)}>
+        <div className={panelHeadingStyle}>{renderNodeHeader(data, this.props.t, isExternal(data.cluster))}</div>
+        <div className={panelBodyStyle}>
           {data.version && (
             <div style={{ textAlign: 'left' }}>
               {`Version: `}


### PR DESCRIPTION
### Describe the change

Polish target panel UI styling (margins, padding, borders, etc.)

I have removed Card component from TargetPanelControlPlane to simplify since there is no kebab toggle in the header (actions)

I am working in the target panel mesh summary, maybe we could add basic information and health status of whole mesh grouped by cluster. It is not finished yet, only listing the infra nodes and health status.

![image](https://github.com/jshaughn/kiali/assets/122779323/9691275f-4105-48e2-a96f-a8e6f12c75ce)




