### PR TITLE
Canary upgrade UI adjustments

### DIFF
--- a/frontend/src/components/MTls/MTLSIcon.tsx
+++ b/frontend/src/components/MTls/MTLSIcon.tsx
@@ -4,8 +4,8 @@ import fullIcon from '../../assets/img/mtls-status-full.svg';
 import hollowIcon from '../../assets/img/mtls-status-partial.svg';
 import fullIconDark from '../../assets/img/mtls-status-full-dark.svg';
 import hollowIconDark from '../../assets/img/mtls-status-partial-dark.svg';
-
-export { fullIcon, hollowIcon, fullIconDark, hollowIconDark };
+import { useKialiTheme } from 'utils/ThemeUtils';
+import { Theme } from 'types/Common';
 
 type MTLSIconProps = {
   icon: string;
@@ -16,22 +16,24 @@ type MTLSIconProps = {
 
 export enum MTLSIconTypes {
   LOCK_FULL = 'LOCK_FULL',
-  LOCK_FULL_DARK = 'LOCK_FULL_DARK',
-  LOCK_HOLLOW = 'LOCK_HOLLOW',
-  LOCK_HOLLOW_DARK = 'LOCK_HOLLOW_DARK'
+  LOCK_HOLLOW = 'LOCK_HOLLOW'
 }
 
-const nameToSource = new Map<string, string>([
-  [MTLSIconTypes.LOCK_FULL, fullIcon],
-  [MTLSIconTypes.LOCK_FULL_DARK, fullIconDark],
-  [MTLSIconTypes.LOCK_HOLLOW, hollowIcon],
-  [MTLSIconTypes.LOCK_HOLLOW_DARK, hollowIconDark]
-]);
-
 export const MTLSIcon: React.FC<MTLSIconProps> = (props: MTLSIconProps) => {
+  const darkTheme = useKialiTheme() === Theme.DARK;
+  const [mtlsIcon, setMtlsIcon] = React.useState('');
+
+  React.useEffect(() => {
+    if (props.icon === MTLSIconTypes.LOCK_FULL) {
+      setMtlsIcon(darkTheme ? fullIcon : fullIconDark);
+    } else if (props.icon === MTLSIconTypes.LOCK_HOLLOW) {
+      setMtlsIcon(darkTheme ? hollowIcon : hollowIconDark);
+    }
+  }, [darkTheme, props.icon]);
+
   return (
     <Tooltip aria-label="mTLS status" position={props.tooltipPosition} enableFlip={true} content={props.tooltipText}>
-      <img className={props.iconClassName} src={nameToSource.get(props.icon)} alt={props.tooltipPosition} />
+      <img key={mtlsIcon} className={props.iconClassName} src={mtlsIcon} alt={props.tooltipPosition} />
     </Tooltip>
   );
 };

--- a/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
+++ b/frontend/src/components/MTls/NamespaceMTLSStatus.tsx
@@ -14,7 +14,7 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
     MTLSStatuses.ENABLED,
     {
       message: 'mTLS is enabled for this namespace',
-      icon: MTLSIconTypes.LOCK_FULL_DARK,
+      icon: MTLSIconTypes.LOCK_FULL,
       showStatus: true
     }
   ],
@@ -22,7 +22,7 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
     MTLSStatuses.ENABLED_EXTENDED,
     {
       message: 'mTLS is enabled for this namespace, extended from Mesh-wide config',
-      icon: MTLSIconTypes.LOCK_FULL_DARK,
+      icon: MTLSIconTypes.LOCK_FULL,
       showStatus: true
     }
   ],
@@ -30,7 +30,7 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
     MTLSStatuses.PARTIALLY,
     {
       message: 'mTLS is partially enabled for this namespace',
-      icon: MTLSIconTypes.LOCK_HOLLOW_DARK,
+      icon: MTLSIconTypes.LOCK_HOLLOW,
       showStatus: true
     }
   ],

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,8 @@ import { App } from './app/App';
 import { globalStyle } from 'styles/GlobalStyle';
 import cssVariables from './styles/variables.module.scss';
 import '@patternfly/patternfly/patternfly.css';
+import '@patternfly/patternfly/patternfly-charts.css';
+import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 import '@patternfly/patternfly/patternfly-addons.css';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/dist/themes/light-border.css';

--- a/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
@@ -17,11 +17,10 @@ import { TitleSizes, Tooltip } from '@patternfly/react-core';
 import { classes } from 'typestyle';
 import { descendents } from '../MeshElems';
 import { renderNodeHeader } from './TargetPanelNode';
-import { WithTranslation } from 'react-i18next';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
-import { withKialiTranslation } from 'utils/I18nUtils';
+import { t } from 'utils/I18nUtils';
 
-type TargetPanelClusterProps = WithTranslation & TargetPanelCommonProps;
+type TargetPanelClusterProps = TargetPanelCommonProps;
 
 type TargetPanelClusterState = {
   clusterNode?: Node<NodeModel, any>;
@@ -38,7 +37,7 @@ const kialiIconStyle = kialiStyle({
   marginRight: '0.25rem'
 });
 
-class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProps, TargetPanelClusterState> {
+export class TargetPanelCluster extends React.Component<TargetPanelClusterProps, TargetPanelClusterState> {
   static readonly panelStyle = {
     backgroundColor: PFColors.BackgroundColor100,
     height: '100%',
@@ -98,7 +97,7 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
       <div id="target-panel-cluster" className={classes(panelStyle, targetPanelStyle)}>
         <div id="target-panel-cluster-heading" className={panelHeadingStyle}>
           {clusterData.isKialiHome && (
-            <Tooltip content={this.props.t('Kiali home cluster')}>
+            <Tooltip content={t('Kiali home cluster')}>
               <KialiIcon.Star />
             </Tooltip>
           )}
@@ -122,19 +121,15 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
             {clusterData.accessible && this.renderKialiLinks(clusterData.kialiInstances)}
             {version && (
               <>
-                {`${this.props.t('Version')}: `}
-                {version}
+                {`${t('Version')}: ${version}`}
                 <br />
               </>
             )}
-            {`${this.props.t('Network')}: `}
-            {clusterData.network ? clusterData.network : 'n/a'}
+            {`${t('Network')}: ${clusterData.network || t('n/a')}`}
             <br />
-            {`${this.props.t('API Endpoint')}: `}
-            {clusterData.apiEndpoint ? clusterData.apiEndpoint : 'n/a'}
+            {`${t('API Endpoint')}: ${clusterData.apiEndpoint || t('n/a')}`}
             <br />
-            {`${this.props.t('Secret Name')}: `}
-            {clusterData.secretName ? clusterData.secretName : 'n/a'}
+            {`${t('Secret Name')}: ${clusterData.secretName || t('n/a')}`}
           </div>
         )}
       </div>
@@ -191,5 +186,3 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
     });
   };
 }
-
-export const TargetPanelCluster = withKialiTranslation()(TargetPanelClusterComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCluster.tsx
@@ -7,7 +7,7 @@ import { getKialiTheme } from 'utils/ThemeUtils';
 import { TargetPanelCommonProps, shouldRefreshData, targetPanelStyle, targetPanelWidth } from './TargetPanelCommon';
 import { kialiIconDark, kialiIconLight } from 'config';
 import { KialiInstance, MeshNodeData, isExternal } from 'types/Mesh';
-import { I18N_NAMESPACE, Theme } from 'types/Common';
+import { Theme } from 'types/Common';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import * as API from '../../../services/Api';
 import * as FilterHelper from '../../../components/FilterList/FilterHelper';
@@ -17,8 +17,9 @@ import { TitleSizes, Tooltip } from '@patternfly/react-core';
 import { classes } from 'typestyle';
 import { descendents } from '../MeshElems';
 import { renderNodeHeader } from './TargetPanelNode';
-import { WithTranslation, withTranslation } from 'react-i18next';
+import { WithTranslation } from 'react-i18next';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
+import { withKialiTranslation } from 'utils/I18nUtils';
 
 type TargetPanelClusterProps = WithTranslation & TargetPanelCommonProps;
 
@@ -113,7 +114,7 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
                 return name1 < name2 ? -1 : 1;
               })
               .map(n => {
-                return renderNodeHeader(n.getData() as MeshNodeData, this.props.t, true, TitleSizes.md);
+                return renderNodeHeader(n.getData() as MeshNodeData, true, TitleSizes.md);
               })}
           </div>
         ) : (
@@ -191,4 +192,4 @@ class TargetPanelClusterComponent extends React.Component<TargetPanelClusterProp
   };
 }
 
-export const TargetPanelCluster = withTranslation(I18N_NAMESPACE)(TargetPanelClusterComponent);
+export const TargetPanelCluster = withKialiTranslation()(TargetPanelClusterComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelCommon.tsx
@@ -7,7 +7,7 @@ import { ValidationTypes } from 'types/IstioObjects';
 import { Status, statusMsg } from 'types/IstioStatus';
 import { Validation } from 'components/Validations/Validation';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { TFunction } from 'react-i18next';
+import { t } from 'utils/I18nUtils';
 
 export interface TargetPanelCommonProps {
   duration: DurationInSeconds;
@@ -74,7 +74,7 @@ export const getTitle = (title: string): React.ReactNode => {
   );
 };
 
-export const getHealthStatus = (data: MeshNodeData, t: TFunction): React.ReactNode => {
+export const getHealthStatus = (data: MeshNodeData): React.ReactNode => {
   let healthSeverity: ValidationTypes;
 
   switch (data.healthData) {

--- a/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelControlPlane.tsx
@@ -35,14 +35,11 @@ import { ControlPlaneMetricsMap, Metric } from 'types/Metrics';
 import { classes } from 'typestyle';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { MeshMTLSStatus } from 'components/MTls/MeshMTLSStatus';
-import { WithTranslation } from 'react-i18next';
-import { withKialiTranslation } from 'utils/I18nUtils';
 
-type TargetPanelControlPlaneProps = TargetPanelCommonProps &
-  WithTranslation & {
-    meshStatus: string;
-    minTLS: string;
-  };
+type TargetPanelControlPlaneProps = TargetPanelCommonProps & {
+  meshStatus: string;
+  minTLS: string;
+};
 
 type TargetPanelControlPlaneState = {
   canaryUpgradeStatus?: CanaryUpgradeStatus;
@@ -79,7 +76,7 @@ const nodeStyle = kialiStyle({
   display: 'flex'
 });
 
-class TargetPanelControlPlaneComponent extends React.Component<
+export class TargetPanelControlPlane extends React.Component<
   TargetPanelControlPlaneProps,
   TargetPanelControlPlaneState
 > {
@@ -458,5 +455,3 @@ class TargetPanelControlPlaneComponent extends React.Component<
     return <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Control plane metrics are not available</div>;
   };
 }
-
-export const TargetPanelControlPlane = withKialiTranslation()(TargetPanelControlPlaneComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelDataPlaneNamespace.tsx
@@ -434,6 +434,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
   private renderCharts(direction: DirectionType): React.ReactNode {
     if (this.state.status) {
       const namespace = this.props.targetNamespace;
+
       return (
         <OverviewCardSparklineCharts
           key={`${namespace}-${direction}`}
@@ -448,7 +449,7 @@ export class TargetPanelDataPlaneNamespace extends React.Component<
       );
     }
 
-    return <div style={{ height: '70px' }} />;
+    return <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Namespace metrics are not available</div>;
   }
 
   private renderStatus(): React.ReactNode {

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -6,8 +6,8 @@ import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/Summa
 import { elems, selectAnd } from '../MeshElems';
 import { MeshAttr, MeshInfraType } from 'types/Mesh';
 import { renderNodeHeader } from './TargetPanelNode';
-import { WithTranslation, withTranslation } from 'react-i18next';
-import { I18N_NAMESPACE } from 'types/Common';
+import { WithTranslation } from 'react-i18next';
+import { withKialiTranslation } from 'utils/I18nUtils';
 
 type TargetPanelMeshState = {
   loading: boolean;
@@ -66,8 +66,8 @@ class TargetPanelMeshComponent extends React.Component<TargetPanelMeshProps, Tar
   }
 
   private renderMeshSummary = (infraNodes: GraphElement[]): React.ReactNode => (
-    <>{infraNodes.map(node => renderNodeHeader(node.getData(), this.props.t, true))}</>
+    <>{infraNodes.map(node => renderNodeHeader(node.getData(), true))}</>
   );
 }
 
-export const TargetPanelMesh = withTranslation(I18N_NAMESPACE)(TargetPanelMeshComponent);
+export const TargetPanelMesh = withKialiTranslation()(TargetPanelMeshComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -6,8 +6,6 @@ import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/Summa
 import { elems, selectAnd } from '../MeshElems';
 import { MeshAttr, MeshInfraType } from 'types/Mesh';
 import { renderNodeHeader } from './TargetPanelNode';
-import { WithTranslation } from 'react-i18next';
-import { withKialiTranslation } from 'utils/I18nUtils';
 
 type TargetPanelMeshState = {
   loading: boolean;
@@ -19,9 +17,9 @@ const defaultState: TargetPanelMeshState = {
   loading: false
 };
 
-type TargetPanelMeshProps = WithTranslation & TargetPanelCommonProps;
+type TargetPanelMeshProps = TargetPanelCommonProps;
 
-class TargetPanelMeshComponent extends React.Component<TargetPanelMeshProps, TargetPanelMeshState> {
+export class TargetPanelMesh extends React.Component<TargetPanelMeshProps, TargetPanelMeshState> {
   constructor(props: TargetPanelMeshProps) {
     super(props);
 
@@ -69,5 +67,3 @@ class TargetPanelMeshComponent extends React.Component<TargetPanelMeshProps, Tar
     <>{infraNodes.map(node => renderNodeHeader(node.getData(), true))}</>
   );
 }
-
-export const TargetPanelMesh = withKialiTranslation()(TargetPanelMeshComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -152,13 +152,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
 
     return (
       <div className={classes(panelStyle, targetPanelStyle)}>
-        <Card
-          id="target-panel-namespace"
-          isCompact={true}
-          className={cardGridStyle}
-          data-test={`${ns}-mesh-target`}
-          style={!this.props.istioAPIEnabled && !this.hasCanaryUpgradeConfigured() ? { height: '96%' } : {}}
-        >
+        <Card id="target-panel-namespace" isCompact={true} className={cardGridStyle} data-test={`${ns}-mesh-target`}>
           <CardHeader
             className={panelHeadingStyle}
             actions={{ actions: <>{namespaceActions}</>, hasNoOffset: false, className: undefined }}
@@ -259,11 +253,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   private getLoading = (): React.ReactNode => {
     return (
       <div className={classes(panelStyle, targetPanelStyle)}>
-        <Card
-          isCompact={true}
-          className={cardGridStyle}
-          style={!this.props.istioAPIEnabled && !this.hasCanaryUpgradeConfigured() ? { height: '96%' } : {}}
-        >
+        <Card isCompact={true} className={cardGridStyle}>
           <CardHeader className={panelHeadingStyle}>
             <Title headingLevel="h5" size={TitleSizes.lg}>
               <span className={namespaceNameStyle}>
@@ -838,6 +828,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
   private renderCharts(): React.ReactNode {
     if (this.state.status) {
       const namespace = this.state.targetNamespace!;
+
       return (
         <OverviewCardSparklineCharts
           key={namespace}
@@ -853,7 +844,7 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
       );
     }
 
-    return <div style={{ height: '70px' }} />;
+    return <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Namespace metrics are not available</div>;
   }
 
   private renderStatus(): React.ReactNode {

--- a/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNamespace.tsx
@@ -187,16 +187,21 @@ export class TargetPanelNamespace extends React.Component<TargetPanelNamespacePr
                 )}
 
                 {isControlPlane && (
-                  <div>
-                    {targetPanelHR}
+                  <>
                     {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
-                      <div>
+                      <>
                         {targetPanelHR}
                         <CanaryUpgradeProgress canaryUpgradeStatus={this.state.canaryUpgradeStatus} />
-                      </div>
+                      </>
                     )}
-                    <div>{this.props.istioAPIEnabled && <div>{this.renderCharts()}</div>}</div>
-                  </div>
+
+                    {this.props.istioAPIEnabled && (
+                      <>
+                        {targetPanelHR}
+                        {this.renderCharts()}
+                      </>
+                    )}
+                  </>
                 )}
               </>
             )}

--- a/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
@@ -7,10 +7,8 @@ import { MeshInfraType, MeshNodeData, isExternal } from 'types/Mesh';
 import { classes } from 'typestyle';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { Title, TitleSizes } from '@patternfly/react-core';
-import { WithTranslation } from 'react-i18next';
-import { withKialiTranslation } from 'utils/I18nUtils';
 
-type TargetPanelNodeProps = WithTranslation & TargetPanelCommonProps;
+type TargetPanelNodeProps = TargetPanelCommonProps;
 
 type TargetPanelNodeState = {
   loading: boolean;
@@ -79,7 +77,7 @@ export function renderNodeHeader(data: MeshNodeData, nameOnly?: boolean, nameSiz
   );
 }
 
-class TargetPanelNodeComponent extends React.Component<TargetPanelNodeProps, TargetPanelNodeState> {
+export class TargetPanelNode extends React.Component<TargetPanelNodeProps, TargetPanelNodeState> {
   constructor(props: TargetPanelNodeProps) {
     super(props);
 
@@ -126,5 +124,3 @@ class TargetPanelNodeComponent extends React.Component<TargetPanelNodeProps, Tar
     );
   }
 }
-
-export const TargetPanelNode = withKialiTranslation()(TargetPanelNodeComponent);

--- a/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelNode.tsx
@@ -7,9 +7,8 @@ import { MeshInfraType, MeshNodeData, isExternal } from 'types/Mesh';
 import { classes } from 'typestyle';
 import { panelBodyStyle, panelHeadingStyle, panelStyle } from 'pages/Graph/SummaryPanelStyle';
 import { Title, TitleSizes } from '@patternfly/react-core';
-import { WithTranslation, withTranslation } from 'react-i18next';
-import { I18N_NAMESPACE } from 'types/Common';
-import { TFunction } from 'react-i18next';
+import { WithTranslation } from 'react-i18next';
+import { withKialiTranslation } from 'utils/I18nUtils';
 
 type TargetPanelNodeProps = WithTranslation & TargetPanelCommonProps;
 
@@ -28,12 +27,7 @@ const nodeStyle = kialiStyle({
   display: 'flex'
 });
 
-export function renderNodeHeader(
-  data: MeshNodeData,
-  t: TFunction,
-  nameOnly?: boolean,
-  nameSize?: TitleSizes
-): React.ReactNode {
+export function renderNodeHeader(data: MeshNodeData, nameOnly?: boolean, nameSize?: TitleSizes): React.ReactNode {
   let pfBadge;
 
   switch (data.infraType) {
@@ -66,7 +60,7 @@ export function renderNodeHeader(
         <span className={nodeStyle}>
           <PFBadge badge={pfBadge} size="global" />
           {data.infraName}
-          {getHealthStatus(data, t)}
+          {getHealthStatus(data)}
         </span>
       </Title>
       {!nameOnly && (
@@ -117,7 +111,7 @@ class TargetPanelNodeComponent extends React.Component<TargetPanelNodeProps, Tar
 
     return (
       <div id="target-panel-node" className={classes(panelStyle, targetPanelStyle)}>
-        <div className={panelHeadingStyle}>{renderNodeHeader(data, this.props.t, isExternal(data.cluster))}</div>
+        <div className={panelHeadingStyle}>{renderNodeHeader(data, isExternal(data.cluster))}</div>
         <div className={panelBodyStyle}>
           {data.version && (
             <div style={{ textAlign: 'left' }}>
@@ -133,4 +127,4 @@ class TargetPanelNodeComponent extends React.Component<TargetPanelNodeProps, Tar
   }
 }
 
-export const TargetPanelNode = withTranslation(I18N_NAMESPACE)(TargetPanelNodeComponent);
+export const TargetPanelNode = withKialiTranslation()(TargetPanelNodeComponent);

--- a/frontend/src/pages/Overview/CanaryUpgradeProgress.tsx
+++ b/frontend/src/pages/Overview/CanaryUpgradeProgress.tsx
@@ -21,35 +21,30 @@ export const CanaryUpgradeProgress: React.FC<Props> = (props: Props) => {
 
   return (
     <div style={{ textAlign: 'center' }} data-test="canary-upgrade">
-      <div>
-        <div>
-          Canary upgrade status
-          <Tooltip
-            position={TooltipPosition.right}
-            content={`There is an in progress canary upgrade from version "${props.canaryUpgradeStatus.currentVersion}" to version "${props.canaryUpgradeStatus.upgradeVersion}"`}
-          >
-            <KialiIcon.Info className={infoStyle} />
-          </Tooltip>
-        </div>
+      <span>Canary upgrade status</span>
 
-        <div style={{ height: 180 }}>
-          <ChartDonutUtilization
-            ariaDesc="Canary upgrade status"
-            ariaTitle="Canary upgrade status"
-            constrainToVisibleArea
-            data={{ x: 'Migrated namespaces', y: migrated }}
-            labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y.toFixed(2)}%` : null)}
-            invert
-            title={`${migrated.toFixed(2)}%`}
-            height={170}
-            themeColor={ChartThemeColor.green}
-          />
-        </div>
+      <Tooltip
+        position={TooltipPosition.right}
+        content={`There is an in progress canary upgrade from version "${props.canaryUpgradeStatus.currentVersion}" to version "${props.canaryUpgradeStatus.upgradeVersion}"`}
+      >
+        <KialiIcon.Info className={infoStyle} />
+      </Tooltip>
 
-        <div>
-          <p>{`${props.canaryUpgradeStatus.migratedNamespaces.length} of ${total} namespaces migrated`}</p>
-        </div>
+      <div style={{ height: '180px' }}>
+        <ChartDonutUtilization
+          ariaDesc="Canary upgrade status"
+          ariaTitle="Canary upgrade status"
+          constrainToVisibleArea
+          data={{ x: 'Migrated namespaces', y: migrated }}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y.toFixed(2)}%` : null)}
+          invert
+          title={`${migrated.toFixed(2)}%`}
+          height={170}
+          themeColor={ChartThemeColor.green}
+        />
       </div>
+
+      <p>{`${props.canaryUpgradeStatus.migratedNamespaces.length} of ${total} namespaces migrated`}</p>
     </div>
   );
 };

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -70,7 +70,6 @@ import { ControlPlaneBadge } from './ControlPlaneBadge';
 import { OverviewStatus } from './OverviewStatus';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
 import { TLSInfo } from 'components/Overview/TLSInfo';
-import { CanaryUpgradeProgress } from './CanaryUpgradeProgress';
 import { ControlPlaneVersionBadge } from './ControlPlaneVersionBadge';
 import { AmbientBadge } from '../../components/Ambient/AmbientBadge';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
@@ -1041,8 +1040,6 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
   render(): React.ReactNode {
     const sm = this.state.displayMode === OverviewDisplayMode.COMPACT ? 3 : 6;
     const md = this.state.displayMode === OverviewDisplayMode.COMPACT ? 3 : 4;
-    const rlg = 4;
-    const lg = 12;
 
     const filteredNamespaces = FilterHelper.runFilters(
       this.state.namespaces,
@@ -1085,24 +1082,8 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                 {filteredNamespaces.map((ns, i) => {
                   return (
                     <GridItem
-                      sm={
-                        ns.name === serverConfig.istioNamespace &&
-                        this.state.displayMode === OverviewDisplayMode.EXPAND &&
-                        this.hasCanaryUpgradeConfigured()
-                          ? isRemoteCluster(ns.annotations)
-                            ? rlg
-                            : lg
-                          : sm
-                      }
-                      md={
-                        ns.name === serverConfig.istioNamespace &&
-                        this.state.displayMode === OverviewDisplayMode.EXPAND &&
-                        this.hasCanaryUpgradeConfigured()
-                          ? isRemoteCluster(ns.annotations)
-                            ? rlg
-                            : lg
-                          : md
-                      }
+                      sm={sm}
+                      md={md}
                       key={`CardItem_${ns.name}_${ns.cluster}`}
                       data-test={`CardItem_${ns.name}_${ns.cluster}`}
                       style={{ margin: '0 0.25rem' }}
@@ -1111,9 +1092,6 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                         isCompact={true}
                         className={cardGridStyle}
                         data-test={`${ns.name}-${OverviewDisplayMode[this.state.displayMode]}`}
-                        style={
-                          !this.props.istioAPIEnabled && !this.hasCanaryUpgradeConfigured() ? { height: '96%' } : {}
-                        }
                       >
                         <CardHeader
                           className={namespaceHeaderStyle}
@@ -1150,7 +1128,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                             !isRemoteCluster(ns.annotations) &&
                             this.state.displayMode === OverviewDisplayMode.EXPAND && (
                               <Grid>
-                                <GridItem md={this.hasCanaryUpgradeConfigured() ? 3 : 6}>
+                                <GridItem md={6}>
                                   {this.renderLabels(ns)}
 
                                   <div style={{ textAlign: 'left' }}>
@@ -1180,16 +1158,8 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                                 {ns.name === serverConfig.istioNamespace && (
                                   <GridItem md={9}>
                                     <Grid>
-                                      {this.state.canaryUpgradeStatus && this.hasCanaryUpgradeConfigured() && (
-                                        <GridItem md={this.props.istioAPIEnabled ? 4 : 9}>
-                                          <CanaryUpgradeProgress canaryUpgradeStatus={this.state.canaryUpgradeStatus} />
-                                        </GridItem>
-                                      )}
-
                                       {this.props.istioAPIEnabled === true && (
-                                        <GridItem md={this.hasCanaryUpgradeConfigured() ? 8 : 12}>
-                                          {this.renderCharts(ns)}
-                                        </GridItem>
+                                        <GridItem md={12}>{this.renderCharts(ns)}</GridItem>
                                       )}
                                     </Grid>
                                   </GridItem>
@@ -1344,6 +1314,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
       if (this.state.displayMode === OverviewDisplayMode.COMPACT) {
         return <NamespaceStatuses key={ns.name} name={ns.name} status={ns.status} type={this.state.type} />;
       }
+
       return (
         <OverviewCardSparklineCharts
           key={ns.name}
@@ -1353,13 +1324,12 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
           direction={this.state.direction}
           metrics={ns.metrics}
           errorMetrics={ns.errorMetrics}
-          // controlPlaneMetrics={ns.controlPlaneMetrics}
           istiodResourceThresholds={this.state.istiodResourceThresholds}
         />
       );
     }
 
-    return <div style={{ height: '70px' }} />;
+    return <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Namespace metrics are not available</div>;
   };
 
   renderIstioConfigStatus = (ns: NamespaceInfo): React.ReactNode => {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -15,7 +15,7 @@ import { IstioConfigDetailsRoute } from 'routes/IstioConfigDetailsRoute';
 import { IstioConfigNewRoute } from 'routes/IstioConfigNewRoute';
 import { GraphRoutePF } from 'routes/GraphRoutePF';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
-import { i18n } from 'i18n';
+import { t } from 'utils/I18nUtils';
 
 /**
  * Return array of objects that describe vertical menu
@@ -24,54 +24,54 @@ import { i18n } from 'i18n';
 const navMenuItems: MenuItem[] = [
   {
     id: 'overview',
-    title: i18n.t('Overview'),
+    title: t('Overview'),
     to: '/overview',
     pathsActive: [/^\/overview\/(.*)/]
   },
   {
     id: 'traffic_graph_cy',
-    title: i18n.t('Traffic Graph [Cy]'),
+    title: t('Traffic Graph [Cy]'),
     to: '/graph/namespaces/',
     pathsActive: [/^\/graph\/(.*)/]
   },
   {
     id: 'traffic_graph_pf',
-    title: i18n.t('Traffic Graph [PF]'),
+    title: t('Traffic Graph [PF]'),
     to: '/graphpf/namespaces/',
     pathsActive: [/^\/graphpf\/(.*)/]
   },
   {
     id: 'applications',
-    title: i18n.t('Applications'),
+    title: t('Applications'),
     to: `/${Paths.APPLICATIONS}`,
     pathsActive: [new RegExp(`^/namespaces/(.*)/${Paths.APPLICATIONS}/(.*)`)]
   },
   {
     id: 'workloads',
-    title: i18n.t('Workloads'),
+    title: t('Workloads'),
     to: `/${Paths.WORKLOADS}`,
     pathsActive: [new RegExp(`^/namespaces/(.*)/${Paths.WORKLOADS}/(.*)`)]
   },
   {
     id: 'services',
-    title: i18n.t('Services'),
+    title: t('Services'),
     to: `/${Paths.SERVICES}`,
     pathsActive: [new RegExp(`^/namespaces/(.*)/${Paths.SERVICES}/(.*)`)]
   },
   {
     id: 'istio',
-    title: i18n.t('Istio Config'),
+    title: t('Istio Config'),
     to: `/${Paths.ISTIO}`,
     pathsActive: [new RegExp(`^/namespaces/(.*)/${Paths.ISTIO}/(.*)`), new RegExp(`/${Paths.ISTIO}/new/(.*)`)]
   },
   {
     id: 'tracing',
-    title: i18n.t('Distributed Tracing'),
+    title: t('Distributed Tracing'),
     to: '/tracing'
   },
   {
     id: 'mesh',
-    title: i18n.t('Mesh'),
+    title: t('Mesh'),
     to: '/mesh'
   }
 ];

--- a/frontend/src/utils/I18nUtils.ts
+++ b/frontend/src/utils/I18nUtils.ts
@@ -1,12 +1,6 @@
 import { TOptions } from 'i18next';
-import { UseTranslationResponse, getI18n, useTranslation, withTranslation } from 'react-i18next';
+import { UseTranslationResponse, getI18n, useTranslation } from 'react-i18next';
 import { I18N_NAMESPACE } from 'types/Common';
-
-/* eslint-disable @typescript-eslint/explicit-function-return-type*/
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types*/
-export const withKialiTranslation = () => {
-  return withTranslation(I18N_NAMESPACE);
-};
 
 /**
  * A Hook for using the i18n translation.

--- a/frontend/src/utils/I18nUtils.ts
+++ b/frontend/src/utils/I18nUtils.ts
@@ -1,0 +1,23 @@
+import { TOptions } from 'i18next';
+import { UseTranslationResponse, getI18n, useTranslation, withTranslation } from 'react-i18next';
+import { I18N_NAMESPACE } from 'types/Common';
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type*/
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types*/
+export const withKialiTranslation = () => {
+  return withTranslation(I18N_NAMESPACE);
+};
+
+/**
+ * A Hook for using the i18n translation.
+ */
+export const useKialiTranslation = (): UseTranslationResponse<string, undefined> => {
+  return useTranslation(I18N_NAMESPACE);
+};
+
+/**
+ * a function to perform translation to I18_NAMESPACE namespace
+ * @param value string to translate
+ * @param options (optional) options for traslations
+ */
+export const t = (value: string, options?: TOptions): string => getI18n().t(value, { ns: I18N_NAMESPACE, ...options });

--- a/frontend/src/utils/ThemeUtils.ts
+++ b/frontend/src/utils/ThemeUtils.ts
@@ -1,8 +1,13 @@
+import { useKialiSelector } from 'hooks/redux';
 import { store } from 'store/ConfigStore';
 import { Theme } from 'types/Common';
 
 export const getKialiTheme = (): Theme => {
   return (store.getState().globalState.theme as Theme) || getDefaultTheme();
+};
+
+export const useKialiTheme = (): string => {
+  return useKialiSelector(state => state.globalState.theme) || getDefaultTheme();
 };
 
 // Get default theme from system settings


### PR DESCRIPTION
### Describe the change

PR changes:
- MTLS icon reacted to theme change
- Import patternfly react-charts css
- Simplify i18n translation in classes and functions (no more t function as input parameter). Need to double check that this method passes CI tests
- Remove upgrade canary chart from Overview page
- Some upgrade canary chart UI styling
- No metrics available messages