### PR TITLE
Determine Jaeger version

### DIFF
--- a/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
+++ b/frontend/src/pages/Mesh/target/TargetPanelMesh.tsx
@@ -39,7 +39,7 @@ export const TargetPanelMesh: React.FC<TargetPanelMeshProps> = (props: TargetPan
       <div style={{ marginBottom: '1rem' }}>
         {renderNodeHeader(clusterData, { nameOnly: true, smallSize: false, hideBadge: clusterData.isExternal })}
         <div className={infoStyle}>
-          {`${t('Version')}: ${clusterData.version || UNKNOWN}`}
+          {!clusterData.isExternal && `${t('Version')}: ${clusterData.version || UNKNOWN}`}
           {infraNodes
             .filter(node => node.getData().cluster === clusterData.cluster)
             .sort((in1, in2) => {

--- a/frontend/src/pages/Overview/OverviewCardDataPlaneNamespace.tsx
+++ b/frontend/src/pages/Overview/OverviewCardDataPlaneNamespace.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DurationInSeconds, I18N_NAMESPACE } from '../../types/Common';
+import { DurationInSeconds } from '../../types/Common';
 import { Metric } from '../../types/Metrics';
 import { getName } from '../../utils/RateIntervals';
 import { PFColors } from 'components/Pf/PfColors';
@@ -7,7 +7,8 @@ import { SparklineChart } from 'components/Charts/SparklineChart';
 import { toVCLine } from 'utils/VictoryChartsUtils';
 import { RichDataPoint, VCLine } from 'types/VictoryChartInfo';
 import { DirectionType } from './OverviewToolbar';
-import { useTranslation } from 'react-i18next';
+import { useKialiTranslation } from 'utils/I18nUtils';
+import { kialiStyle } from 'styles/StyleUtils';
 
 type Props = {
   direction: DirectionType;
@@ -25,8 +26,16 @@ const showMetrics = (metrics: Metric[] | undefined): boolean => {
   return false;
 };
 
+const noTrafficStyle = kialiStyle({
+  padding: '0.5rem 0',
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center'
+});
+
 export const OverviewCardDataPlaneNamespace: React.FC<Props> = (props: Props) => {
-  const { t } = useTranslation(I18N_NAMESPACE);
+  const { t } = useKialiTranslation();
 
   let series: VCLine<RichDataPoint>[] = [];
 
@@ -42,50 +51,34 @@ export const OverviewCardDataPlaneNamespace: React.FC<Props> = (props: Props) =>
     }
   }
 
-  if (series.length === 0) {
-    return (
-      <div
-        style={{
-          width: '100%',
-          verticalAlign: 'top'
-        }}
-      >
-        <div style={{ paddingTop: '0.5rem' }}>{`${t('No')} ${t(props.direction.toLowerCase())} ${t('traffic')}`}</div>
-      </div>
-    );
-  }
-
   return (
-    <div
-      style={{
-        width: '100%',
-        height: 130,
-        verticalAlign: 'top'
-      }}
-    >
-      <div>
-        <></>
-      </div>
-      <>
-        <div
-          style={{ paddingTop: '0.5rem' }}
-          data-test={`sparkline-${props.direction.toLowerCase()}-duration-${getName(props.duration).toLowerCase()}`}
-        >
-          {`${t(props.direction)} ${t('traffic')}, ${getName(props.duration).toLowerCase()}`}
-        </div>
+    <div style={{ height: '100%' }}>
+      {series.length > 0 && (
+        <>
+          <div
+            style={{ paddingTop: '0.5rem' }}
+            data-test={`sparkline-${props.direction.toLowerCase()}-duration-${getName(props.duration).toLowerCase()}`}
+          >
+            {`${t(props.direction)} ${t('traffic')}, ${getName(props.duration).toLowerCase()}`}
+          </div>
 
-        <SparklineChart
-          name="traffics"
-          height={85}
-          showLegend={false}
-          showYAxis={true}
-          showXAxisValues={true}
-          padding={{ top: 10, left: 30, right: 30, bottom: 30 }}
-          tooltipFormat={dp => `${(dp.x as Date).toLocaleStringWithConditionalDate()}\n${dp.y.toFixed(2)} ${dp.name}`}
-          series={series}
-          labelName="ops"
-        />
-      </>
+          <SparklineChart
+            name="traffics"
+            height={85}
+            showLegend={false}
+            showYAxis={true}
+            showXAxisValues={true}
+            padding={{ top: 10, left: 30, right: 30, bottom: 30 }}
+            tooltipFormat={dp => `${(dp.x as Date).toLocaleStringWithConditionalDate()}\n${dp.y.toFixed(2)} ${dp.name}`}
+            series={series}
+            labelName="ops"
+          />
+        </>
+      )}
+
+      {series.length === 0 && (
+        <div className={noTrafficStyle}>{`${t('No')} ${t(props.direction.toLowerCase())} ${t('traffic')}`}</div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Overview/OverviewPage.tsx
+++ b/frontend/src/pages/Overview/OverviewPage.tsx
@@ -35,7 +35,6 @@ import { OverviewToolbar, OverviewDisplayMode, OverviewType, DirectionType } fro
 import { NamespaceInfo, NamespaceStatus } from '../../types/NamespaceInfo';
 import { NamespaceMTLSStatus } from '../../components/MTls/NamespaceMTLSStatus';
 import { RenderComponentScroll } from '../../components/Nav/Page';
-import { NamespaceStatuses } from './NamespaceStatuses';
 import { OverviewCardSparklineCharts } from './OverviewCardSparklineCharts';
 import { OverviewTrafficPolicies } from './OverviewTrafficPolicies';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
@@ -69,11 +68,9 @@ import { ValidationSummaryLink } from '../../components/Link/ValidationSummaryLi
 import { ControlPlaneBadge } from './ControlPlaneBadge';
 import { OverviewStatus } from './OverviewStatus';
 import { IstiodResourceThresholds } from 'types/IstioStatus';
-import { TLSInfo } from 'components/Overview/TLSInfo';
 import { ControlPlaneVersionBadge } from './ControlPlaneVersionBadge';
 import { AmbientBadge } from '../../components/Ambient/AmbientBadge';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
-import { isRemoteCluster } from './OverviewCardControlPlaneNamespace';
 import { ApiError } from 'types/Api';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { IstioConfigList } from 'types/IstioConfigList';
@@ -1124,90 +1121,9 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                             </div>
                           )}
 
-                          {ns.name === serverConfig.istioNamespace &&
-                            !isRemoteCluster(ns.annotations) &&
-                            this.state.displayMode === OverviewDisplayMode.EXPAND && (
-                              <Grid>
-                                <GridItem md={6}>
-                                  {this.renderLabels(ns)}
-
-                                  <div style={{ textAlign: 'left' }}>
-                                    <div style={{ display: 'inline-block', width: '125px' }}>
-                                      {this.props.t('Istio config')}
-                                    </div>
-
-                                    {ns.tlsStatus && (
-                                      <span>
-                                        <NamespaceMTLSStatus status={ns.tlsStatus.status} />
-                                      </span>
-                                    )}
-
-                                    {this.props.istioAPIEnabled ? this.renderIstioConfigStatus(ns) : 'N/A'}
-                                  </div>
-
-                                  {ns.status && (
-                                    <NamespaceStatuses
-                                      key={ns.name}
-                                      name={ns.name}
-                                      status={ns.status}
-                                      type={this.state.type}
-                                    />
-                                  )}
-                                </GridItem>
-
-                                {ns.name === serverConfig.istioNamespace && (
-                                  <GridItem md={9}>
-                                    <Grid>
-                                      {this.props.istioAPIEnabled === true && (
-                                        <GridItem md={12}>{this.renderCharts(ns)}</GridItem>
-                                      )}
-                                    </Grid>
-                                  </GridItem>
-                                )}
-                              </Grid>
-                            )}
-
-                          {ns.name === serverConfig.istioNamespace &&
-                            isRemoteCluster(ns.annotations) &&
-                            this.state.displayMode === OverviewDisplayMode.EXPAND && (
-                              <div>
-                                {this.renderLabels(ns)}
-
-                                <div style={{ textAlign: 'left' }}>
-                                  <div style={{ display: 'inline-block', width: '125px' }}>
-                                    {this.props.t('Istio config')}
-                                  </div>
-
-                                  {ns.tlsStatus && (
-                                    <span>
-                                      <NamespaceMTLSStatus status={ns.tlsStatus.status} />
-                                    </span>
-                                  )}
-
-                                  {this.props.istioAPIEnabled ? this.renderIstioConfigStatus(ns) : 'N/A'}
-                                </div>
-
-                                {this.renderStatus(ns)}
-
-                                {this.state.displayMode === OverviewDisplayMode.EXPAND && (
-                                  <TLSInfo
-                                    certificatesInformationIndicators={
-                                      serverConfig.kialiFeatureFlags.certificatesInformationIndicators.enabled
-                                    }
-                                    version={this.props.minTLS}
-                                  ></TLSInfo>
-                                )}
-
-                                {this.state.displayMode === OverviewDisplayMode.EXPAND && (
-                                  <div style={{ height: '110px' }} />
-                                )}
-                              </div>
-                            )}
-
-                          {((ns.name !== serverConfig.istioNamespace &&
-                            this.state.displayMode === OverviewDisplayMode.EXPAND) ||
+                          {(this.state.displayMode === OverviewDisplayMode.EXPAND ||
                             this.state.displayMode === OverviewDisplayMode.COMPACT) && (
-                            <div>
+                            <>
                               {this.renderLabels(ns)}
 
                               <div style={{ textAlign: 'left' }}>
@@ -1226,7 +1142,7 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
                               {this.renderStatus(ns)}
 
                               {this.state.displayMode === OverviewDisplayMode.EXPAND && this.renderCharts(ns)}
-                            </div>
+                            </>
                           )}
                         </CardBody>
                       </Card>
@@ -1310,26 +1226,24 @@ export class OverviewPageComponent extends React.Component<OverviewProps, State>
   };
 
   renderCharts = (ns: NamespaceInfo): React.ReactNode => {
-    if (ns.status) {
-      if (this.state.displayMode === OverviewDisplayMode.COMPACT) {
-        return <NamespaceStatuses key={ns.name} name={ns.name} status={ns.status} type={this.state.type} />;
-      }
-
-      return (
-        <OverviewCardSparklineCharts
-          key={ns.name}
-          name={ns.name}
-          annotations={ns.annotations}
-          duration={FilterHelper.currentDuration()}
-          direction={this.state.direction}
-          metrics={ns.metrics}
-          errorMetrics={ns.errorMetrics}
-          istiodResourceThresholds={this.state.istiodResourceThresholds}
-        />
-      );
-    }
-
-    return <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Namespace metrics are not available</div>;
+    return (
+      <div style={{ height: '130px' }}>
+        {ns.status ? (
+          <OverviewCardSparklineCharts
+            key={ns.name}
+            name={ns.name}
+            annotations={ns.annotations}
+            duration={FilterHelper.currentDuration()}
+            direction={this.state.direction}
+            metrics={ns.metrics}
+            errorMetrics={ns.errorMetrics}
+            istiodResourceThresholds={this.state.istiodResourceThresholds}
+          />
+        ) : (
+          <div style={{ padding: '1.5rem 0', textAlign: 'center' }}>Namespace metrics are not available</div>
+        )}
+      </div>
+    );
   };
 
   renderIstioConfigStatus = (ns: NamespaceInfo): React.ReactNode => {

--- a/status/versions.go
+++ b/status/versions.go
@@ -193,15 +193,46 @@ type p8sResponseVersion struct {
 	Revision string `json:"revision"`
 }
 
+type jaegerResponseVersion struct {
+	Version string `json:"gitVersion"`
+}
+
 func tracingVersion() (*ExternalServiceInfo, error) {
 	tracingConfig := config.Get().ExternalServices.Tracing
 
 	if !tracingConfig.Enabled {
 		return nil, nil
 	}
+
 	product := ExternalServiceInfo{}
 	product.Name = string(tracingConfig.Provider)
 	product.Url = tracingConfig.URL
+
+	if product.Url != "" {
+		// try to determine version by querying
+		if tracingConfig.Provider == config.JaegerProvider {
+			body, statusCode, _, err := httputil.HttpGet(product.Url, nil, 10*time.Second, nil, nil)
+			if err != nil || statusCode > 399 {
+				log.Infof("jaeger version check failed: url=[%v], code=[%v]", product.Url, statusCode)
+			} else {
+				// Jaeger does not provide api to get version, so it is obtained from js function inside html main page
+				// const JAEGER_VERSION = {"gitCommit: xxx, gitVersion: yyy, buildDate: zzz"}
+				bodyStr := string(body)
+				jaegerVersionConst := "const JAEGER_VERSION = "
+				jsonStartIndex := strings.Index(bodyStr, jaegerVersionConst) + len(jaegerVersionConst)
+				jsonEndIndex := jsonStartIndex + strings.Index(bodyStr[jsonStartIndex:], ";") //version json ends with ;
+				jaegerVersion := bodyStr[jsonStartIndex:jsonEndIndex]
+
+				jaegerV := new(jaegerResponseVersion)
+				err = json.Unmarshal([]byte(jaegerVersion), &jaegerV)
+				if err == nil {
+					product.Version = jaegerV.Version
+				}
+			}
+		}
+		// TODO determine version for Tempo
+	}
+
 	product.TempoConfig = tracingConfig.TempoConfig
 
 	return &product, nil


### PR DESCRIPTION
### Describe the change 

PR changes:
- Determine Jaeger version: I haven't seen any Jaeger api to retrieve version information, so I have had to unmarshal main HTML page to retrieve the version (a bit hacky but it works).

- The removal of 'No inbound traffic' margins breaks the height of overview cards:
![image](https://github.com/jshaughn/kiali/assets/122779323/2cd6ae5a-d59b-4fdb-adf9-bde4ec45eee6)

I have fixed that and cleaned up the Overview page code. As far as I know, there is no distinction between control planes and data planes in the overview cards.

