### PR TITLE
Simplify the PFT custom edge path style

### DIFF
--- a/frontend/src/pages/GraphPF/styles/styleEdge.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleEdge.tsx
@@ -46,7 +46,7 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
       $nest: {
         '& .pf-topology__edge__link': data.pathStyle,
         '& .pf-topology-connector-arrow': {
-          ...data.pathStyle,
+          stroke: data.pathStyle.stroke,
           fill: data.pathStyle.stroke
         }
       }

--- a/frontend/src/pages/GraphPF/styles/styleEdge.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleEdge.tsx
@@ -42,49 +42,16 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
 
   // when selected keep the selection styling, otherwise apply our custom path styling
   if (!rest.selected) {
-    // Change edge color according to the pathStyle
     const edgeClass = kialiStyle({
       $nest: {
-        '& .pf-topology__edge__link': data.pathStyle
-      }
-    });
-    cssClasses.push(edgeClass);
-
-    const edgeHoverClass = kialiStyle({
-      $nest: {
-        '& .pf-topology__edge.pf-m-hover': {
-          $nest: {
-            '& .pf-topology__edge__link, & .pf-topology-connector-arrow': data.pathStyle
-          }
-        }
-      }
-    });
-    cssClasses.push(edgeHoverClass);
-
-    // Change connector color according to the pathStyle
-    const connectorClass = kialiStyle({
-      $nest: {
+        '& .pf-topology__edge__link': data.pathStyle,
         '& .pf-topology-connector-arrow': {
-          stroke: data.pathStyle.stroke,
+          ...data.pathStyle,
           fill: data.pathStyle.stroke
         }
       }
     });
-    cssClasses.push(connectorClass);
-
-    const edgeConnectorArrowHoverStyles = kialiStyle({
-      $nest: {
-        '& .pf-topology__edge.pf-m-hover': {
-          $nest: {
-            '& .pf-topology-connector-arrow': {
-              stroke: data.pathStyle.stroke,
-              fill: data.pathStyle.stroke
-            }
-          }
-        }
-      }
-    });
-    cssClasses.push(edgeConnectorArrowHoverStyles);
+    cssClasses.push(edgeClass);
   }
 
   // If has spans, add the span overlay


### PR DESCRIPTION
Refactor the custom edge path styles slightly (hover CSS classes are either being overwritten or have the same style as non-hover classes).