### PR TITLE
Apply same node shape to focus nodes and customize selection CSS

### DIFF
--- a/frontend/src/components/Pf/PfColors.tsx
+++ b/frontend/src/components/Pf/PfColors.tsx
@@ -72,6 +72,7 @@ export enum PFColors {
   BackgroundColor100 = 'var(--pf-v5-global--BackgroundColor--100)',
   BackgroundColor150 = 'var(--pf-v5-global--BackgroundColor--150)',
   BackgroundColor200 = 'var(--pf-v5-global--BackgroundColor--200)',
+  BackgroundColorLight300 = 'var(--pf-v5-global--BackgroundColor--light-300)',
 
   // PF standard colors (compatible with dark mode)
   Color100 = 'var(--pf-v5-global--Color--100)',

--- a/frontend/src/pages/GraphPF/styles/styleEdge.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleEdge.tsx
@@ -40,19 +40,51 @@ const StyleEdgeComponent: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
     data.onHover(element, false);
   };
 
-  // when selected keep the selection styling, otherwise apply our custom path styling
-  if (!rest.selected) {
-    const edgeClass = kialiStyle({
-      $nest: {
-        '& .pf-topology__edge__link': data.pathStyle,
-        '& .pf-topology-connector-arrow': {
-          stroke: data.pathStyle.stroke,
-          fill: data.pathStyle.stroke
+  const edgeClass = kialiStyle({
+    $nest: {
+      // node status color on edges
+      '& .pf-topology__edge__link': data.pathStyle,
+      '& .pf-topology-connector-arrow': {
+        stroke: data.pathStyle.stroke,
+        fill: data.pathStyle.stroke
+      },
+
+      // active color for selected edges
+      '&.pf-m-selected': {
+        $nest: {
+          '& .pf-topology__edge__link': {
+            stroke: PFColors.Active
+          },
+          '& .pf-topology-connector-arrow': {
+            stroke: PFColors.Active,
+            fill: PFColors.Active,
+            strokeWidth: 1
+          }
+        }
+      },
+
+      // maintain the selection background on hover (only for selected edges)
+      '&.pf-m-selected.pf-m-hover': {
+        $nest: {
+          '.pf-topology__edge__background': {
+            stroke: 'var(--pf-topology__edge--m-selected--background--Stroke)'
+          }
+        }
+      },
+
+      // pointer cursor on hover
+      '&.pf-m-hover': {
+        cursor: 'pointer',
+        $nest: {
+          '.pf-topology__edge__background': {
+            cursor: 'pointer'
+          }
         }
       }
-    });
-    cssClasses.push(edgeClass);
-  }
+    }
+  });
+
+  cssClasses.push(edgeClass);
 
   // If has spans, add the span overlay
   if (data.hasSpans) {

--- a/frontend/src/pages/GraphPF/styles/styleGroup.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleGroup.tsx
@@ -61,6 +61,30 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
     data.onHover(element, false);
   };
 
+  // the selected group has an active border, but the background remains unchanged
+  const selectedGroupStyle = {
+    $nest: {
+      '& .pf-topology__group__background': {
+        fill: PFColors.BackgroundColorLight300,
+        stroke: PFColors.Active
+      },
+      '&.pf-m-alt-group .pf-topology__group__background': {
+        fill: 'var(--pf-topology__group--m-alt-group--topology__group__background--Fill)',
+        stroke: PFColors.Active
+      }
+    }
+  };
+
+  const groupClass = kialiStyle({
+    $nest: {
+      '&.pf-m-selected': selectedGroupStyle,
+      '&.pf-m-selected.pf-m-hover': selectedGroupStyle,
+      '&.pf-m-hover .pf-topology__group__background': {
+        stroke: PFColors.Color200
+      }
+    }
+  });
+
   const passedData = React.useMemo(() => {
     const newData = { ...data };
     Object.keys(newData).forEach(key => {
@@ -97,6 +121,7 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
         />
       )}
       <DefaultGroup
+        className={groupClass}
         element={element}
         collapsedWidth={collapsedWidth}
         collapsedHeight={collapsedHeight}

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -5,6 +5,7 @@ import {
   NodeShape,
   observer,
   ScaleDetailsLevel,
+  ShapeProps,
   useHover,
   WithSelectionProps
 } from '@patternfly/react-topology';
@@ -62,11 +63,22 @@ const renderIcon = (element: Node): React.ReactNode => {
   );
 };
 
+const getNodeShape = (node: Node): React.FunctionComponent<ShapeProps> => {
+  switch (node.getNodeShape()) {
+    case NodeShape.rhombus:
+      return Triangle;
+    case NodeShape.trapezoid:
+      return Plate;
+    default:
+      return getShapeComponent(node);
+  }
+};
+
 const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
   const data = element.getData();
   const detailsLevel = useDetailsLevel();
   const [hover, hoverRef] = useHover();
-  const ShapeComponent = getShapeComponent(element);
+  const ShapeComponent = getNodeShape(element);
 
   const ColorFind = PFColors.Gold400;
   const ColorFocus = PFColors.Blue200;
@@ -132,20 +144,11 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
         {...rest}
         {...passedData}
         attachments={hover || detailsLevel === ScaleDetailsLevel.high ? data.attachments : undefined}
-        getCustomShape={(node: Node) => {
-          switch (node.getNodeShape()) {
-            case NodeShape.rhombus:
-              return Triangle;
-            case NodeShape.trapezoid:
-              return Plate;
-            default:
-              return getShapeComponent(node);
-          }
-        }}
+        getCustomShape={getNodeShape}
         scaleLabel={hover && detailsLevel !== ScaleDetailsLevel.low}
         scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
         showLabel={hover || detailsLevel === ScaleDetailsLevel.high}
-        showStatusBackground={detailsLevel === ScaleDetailsLevel.low || rest.selected}
+        showStatusBackground={detailsLevel === ScaleDetailsLevel.low}
       >
         {(hover || detailsLevel !== ScaleDetailsLevel.low) && renderIcon(element)}
       </DefaultNode>

--- a/frontend/src/pages/GraphPF/styles/styleNode.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleNode.tsx
@@ -117,6 +117,18 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
     data.onHover(element, false);
   };
 
+  const nodeClass = kialiStyle({
+    $nest: {
+      '&.pf-m-hover': {
+        cursor: 'pointer'
+      },
+      '&.pf-m-selected .pf-topology__node__background': {
+        stroke: PFColors.Active,
+        strokeWidth: 6
+      }
+    }
+  });
+
   const passedData = React.useMemo(() => {
     const newData = { ...data };
     if (detailsLevel !== ScaleDetailsLevel.high) {
@@ -140,6 +152,7 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
       {data.isFind && <ShapeComponent className={findOverlayStyle} width={width} height={height} element={element} />}
       {data.isFocus && <ShapeComponent className={focusOverlayStyle} width={width} height={height} element={element} />}
       <DefaultNode
+        className={nodeClass}
         element={element}
         {...rest}
         {...passedData}
@@ -148,7 +161,7 @@ const StyleNodeComponent: React.FC<StyleNodeProps> = ({ element, ...rest }) => {
         scaleLabel={hover && detailsLevel !== ScaleDetailsLevel.low}
         scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
         showLabel={hover || detailsLevel === ScaleDetailsLevel.high}
-        showStatusBackground={detailsLevel === ScaleDetailsLevel.low}
+        showStatusBackground={detailsLevel !== ScaleDetailsLevel.high}
       >
         {(hover || detailsLevel !== ScaleDetailsLevel.low) && renderIcon(element)}
       </DefaultNode>

--- a/frontend/src/pages/Mesh/styles/MeshEdge.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshEdge.tsx
@@ -41,46 +41,14 @@ const MeshEdgeComponent: React.FC<MeshEdgeProps> = ({ element, ...rest }) => {
   // Change edge color according to the pathStyle
   const edgeClass = kialiStyle({
     $nest: {
-      '& .pf-topology__edge__link': data.pathStyle
-    }
-  });
-  cssClasses.push(edgeClass);
-
-  const edgeHoverClass = kialiStyle({
-    $nest: {
-      '& .pf-topology__edge.pf-m-hover': {
-        $nest: {
-          '& .pf-topology__edge__link, & .pf-topology-connector-arrow': data.pathStyle
-        }
-      }
-    }
-  });
-  cssClasses.push(edgeHoverClass);
-
-  // Change connector color according to the pathStyle
-  const connectorClass = kialiStyle({
-    $nest: {
+      '& .pf-topology__edge__link': data.pathStyle,
       '& .pf-topology-connector-arrow': {
         stroke: data.pathStyle.stroke,
         fill: data.pathStyle.stroke
       }
     }
   });
-  cssClasses.push(connectorClass);
-
-  const edgeConnectorArrowHoverStyles = kialiStyle({
-    $nest: {
-      '& .pf-topology__edge.pf-m-hover': {
-        $nest: {
-          '& .pf-topology-connector-arrow': {
-            stroke: data.pathStyle.stroke,
-            fill: data.pathStyle.stroke
-          }
-        }
-      }
-    }
-  });
-  cssClasses.push(edgeConnectorArrowHoverStyles);
+  cssClasses.push(edgeClass);
 
   if (data.isFind) {
     const findClass = kialiStyle({


### PR DESCRIPTION
PR to apply the same node shape to find/focus shape components:

Before:
![image](https://github.com/user-attachments/assets/7eaafc52-8a3f-4eec-8e45-46ec9315145b)

After:
![image](https://github.com/user-attachments/assets/f3ec7cbb-4528-4c09-bec5-0486a1f81f90)

Additionally, I have played a bit with node, edge and group CSS for hover and selection:
- The cursor changes when hovering over nodes and edges.
- Group and node selection don't change the background, only the border, like cytoscape.

Before:
![image](https://github.com/user-attachments/assets/64a4ef79-6661-4cea-a477-52bba9a06544)

After:
![image](https://github.com/user-attachments/assets/8c53ead9-0beb-47c4-912d-add3c4274ba2)

Before:
![image](https://github.com/user-attachments/assets/ef3ca0cd-f673-4ca4-9cc2-b67973c67a2e)

After:
![image](https://github.com/user-attachments/assets/d288f913-5550-4afe-863a-948921487f08)

- For nodes, this only applies when the detail level is high; otherwise, the node background is filled.

![image](https://github.com/user-attachments/assets/e0c4a4a3-f4d0-4c1d-83dc-48cf393db224)


An alternative for node selection with a high detail level could be to increase the border width without changing the color to active blue (both are valid to me):

![image](https://github.com/user-attachments/assets/5c3b6a65-42c7-4f0b-ace7-0497593fd096)


