### PR TITLE
Use cache for waypoints load

### DIFF
--- a/business/workloads.go
+++ b/business/workloads.go
@@ -187,6 +187,7 @@ func (in *WorkloadService) GetAllWorkloads(ctx context.Context, cluster string, 
 
 // GetAllGateways fetches all gateway workloads across every namespace in the cluster.
 func (in *WorkloadService) GetAllGateways(ctx context.Context, cluster string, labelSelector string) (models.Workloads, error) {
+
 	workloads, err := in.GetAllWorkloads(ctx, cluster, labelSelector)
 	if err != nil {
 		return nil, err
@@ -2311,17 +2312,23 @@ func (in *WorkloadService) GetWaypointsForWorkload(ctx context.Context, workload
 
 	// then, get the waypoint workloads to filter out "forNone" waypoints
 	for _, waypoint := range waypoints {
-		waypointWorkload, err := in.fetchWorkload(ctx, WorkloadCriteria{Cluster: workload.Cluster, Namespace: waypoint.Namespace, WorkloadName: waypoint.Name, WorkloadGVK: schema.GroupVersionKind{}, IncludeWaypoints: false})
-		if err != nil {
-			log.Debugf("GetWaypointsForWorkload: Error fetching waypoint workload %s", err.Error())
-			return nil
+		waypointWorkloads := in.cache.GetWaypointList()
+		found := false
+		waypointWorkload := models.Workload{}
+		for _, ww := range waypointWorkloads {
+			if ww.Name == workload.Name && ww.Namespace == workload.Namespace && ww.Cluster == workload.Cluster {
+				found = true
+				waypointWorkload = *ww
+			}
 		}
-		waypointFor, waypointForFound := waypointWorkload.Labels[config.WaypointFor]
-		if !waypointForFound || waypointFor != config.WaypointForNone {
-			key := fmt.Sprintf("%s_%s_%s", workload.Cluster, waypoint.Namespace, waypoint.Name)
-			if waypointWorkload != nil && !workloadsMap[key] {
-				workloadsList = append(workloadsList, models.WorkloadReferenceInfo{Name: waypoint.Name, Namespace: waypoint.Namespace, Cluster: waypoint.Cluster, Type: waypointWorkload.WaypointFor()})
-				workloadsMap[key] = true
+		if found {
+			waypointFor, waypointForFound := waypointWorkload.Labels[config.WaypointFor]
+			if !waypointForFound || waypointFor != config.WaypointForNone {
+				key := fmt.Sprintf("%s_%s_%s", workload.Cluster, waypoint.Namespace, waypoint.Name)
+				if !workloadsMap[key] {
+					workloadsList = append(workloadsList, models.WorkloadReferenceInfo{Name: waypoint.Name, Namespace: waypoint.Namespace, Cluster: waypoint.Cluster, Type: waypointWorkload.WaypointFor()})
+					workloadsMap[key] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
** Describe the change **

Another performance improvement. This method was not using the cache and it was fetching workloads.
Makes a significant improvement from 9.14 seconds to 2.89:

![image](https://github.com/user-attachments/assets/2d08aca4-e582-4bac-9d6e-a41c0e5d4541)

![image](https://github.com/user-attachments/assets/3d2f97c5-c1fe-442a-847a-a72d3c867008)


** Issue reference **

Ref. https://github.com/kiali/kiali/pull/8277 