### PR TITLE
Move actions toolbar from header to tab bar level

### DIFF
--- a/frontend/src/components/Nav/Page/RenderHeader.tsx
+++ b/frontend/src/components/Nav/Page/RenderHeader.tsx
@@ -9,7 +9,7 @@ import { PFColors } from 'components/Pf/PfColors';
 const containerStyle = kialiStyle({
   backgroundColor: PFColors.BackgroundColor100,
   flexShrink: 0,
-  paddingBottom: '1rem'
+  paddingBottom: '0.5rem'
 });
 
 const headerRowStyle = kialiStyle({
@@ -23,43 +23,26 @@ const rightToolbarStyle = kialiStyle({
   marginLeft: 'auto'
 });
 
-const actionsToolbarPositionStyle = kialiStyle({
-  position: 'absolute',
-  right: '3rem',
-  top: '9rem',
-  zIndex: 1
-});
-
 type ReduxProps = {
   kiosk: string;
 };
 
 type RenderHeaderProps = ReduxProps & {
-  actionsToolbar?: React.ReactNode;
-  actionsToolbarTop?: string;
   children?: React.ReactNode;
   rightToolbar?: React.ReactNode;
 };
 
 const RenderHeaderComponent: React.FC<RenderHeaderProps> = (props: RenderHeaderProps) => {
   return isKiosk(props.kiosk) ? null : (
-    <>
-      <div className={containerStyle}>
-        <div className={headerRowStyle}>
-          <BreadcrumbView />
+    <div className={containerStyle}>
+      <div className={headerRowStyle}>
+        <BreadcrumbView />
 
-          {props.rightToolbar && <div className={rightToolbarStyle}>{props.rightToolbar}</div>}
-        </div>
-
-        {props.children}
+        {props.rightToolbar && <div className={rightToolbarStyle}>{props.rightToolbar}</div>}
       </div>
 
-      {props.actionsToolbar && (
-        <div className={actionsToolbarPositionStyle} style={{ top: props.actionsToolbarTop ?? '9rem' }}>
-          {props.actionsToolbar}
-        </div>
-      )}
-    </>
+      {props.children}
+    </div>
   );
 };
 

--- a/frontend/src/components/Tab/Tabs.tsx
+++ b/frontend/src/components/Tab/Tabs.tsx
@@ -6,6 +6,7 @@ import { PFColors } from 'components/Pf/PfColors';
 import { classes } from 'typestyle';
 
 type TabsProps = {
+  actionsToolbar?: React.ReactNode;
   activeTab: string;
   className?: string;
   defaultTab: string;
@@ -30,7 +31,15 @@ const flexTabWrapperStyle = kialiStyle({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
-  minHeight: 0
+  minHeight: 0,
+  position: 'relative'
+});
+
+const actionsToolbarStyle = kialiStyle({
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  zIndex: 1
 });
 
 type TabElement = React.ReactElement<TabProps, React.JSXElementConstructor<TabProps>>;
@@ -111,6 +120,8 @@ export class ParameterizedTabs extends React.Component<TabsProps> {
   render(): React.ReactNode {
     return (
       <div className={classes(flexTabWrapperStyle, this.props.className, tabStyle)}>
+        {this.props.actionsToolbar && <div className={actionsToolbarStyle}>{this.props.actionsToolbar}</div>}
+
         <Tabs
           id={this.props.id}
           activeKey={this.activeIndex()}

--- a/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/frontend/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -23,10 +23,18 @@ import { IstioActionDropdown } from '../../components/IstioActions/IstioActionsD
 import { IstioActionButtons } from '../../components/IstioActions/IstioActionsButtons';
 import { HistoryManager, router } from '../../app/History';
 import { Paths } from '../../config';
-import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
+import { getGVKTypeString, getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
+import { PFBadge } from '../../components/Pf/PfBadges';
+import { GVKToBadge } from '../../components/VirtualList/Config';
 import { kialiStyle } from 'styles/StyleUtils';
 import { classes } from 'typestyle';
-import { constrainedScrollStyle, flexFillStyle, noShrinkStyle } from 'styles/FlexStyles';
+import {
+  constrainedScrollStyle,
+  detailTitleMainStyle,
+  detailTitleRowStyle,
+  flexFillStyle,
+  noShrinkStyle
+} from 'styles/FlexStyles';
 import { ParameterizedTabs, activeTab } from '../../components/Tab/Tabs';
 import {
   Drawer,
@@ -36,7 +44,10 @@ import {
   DrawerContentBody,
   DrawerHead,
   DrawerPanelContent,
-  Tab
+  Tab,
+  Title,
+  TitleSizes,
+  TooltipPosition
 } from '@patternfly/react-core';
 import { showInNotificationCenter } from '../../utils/IstioValidationUtils';
 import { Refresh } from '../../components/Refresh/Refresh';
@@ -668,10 +679,29 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
       <>
         <RefreshNotifier onTick={this.onRefresh} />
 
-        <RenderHeader
-          rightToolbar={<Refresh id="config_details_refresh" />}
-          actionsToolbar={!this.state.error ? this.renderActions() : undefined}
-        />
+        <RenderHeader rightToolbar={<Refresh id="config_details_refresh" />}>
+          {this.state.istioObjectDetails && (
+            <div className={detailTitleRowStyle}>
+              <div className={detailTitleMainStyle}>
+                <PFBadge
+                  badge={
+                    GVKToBadge[
+                      getGVKTypeString({
+                        Group: this.props.istioConfigId.objectGroup,
+                        Kind: this.props.istioConfigId.objectKind,
+                        Version: this.props.istioConfigId.objectVersion
+                      })
+                    ]
+                  }
+                  position={TooltipPosition.top}
+                />
+                <Title headingLevel="h1" size={TitleSizes.xl} style={{ margin: 0, flexShrink: 0 }}>
+                  {this.props.istioConfigId.objectName}
+                </Title>
+              </div>
+            </div>
+          )}
+        </RenderHeader>
 
         {this.state.error && <ErrorSection error={this.state.error} />}
 
@@ -679,6 +709,7 @@ class IstioConfigDetailsPageComponent extends React.Component<IstioConfigDetails
           <ParameterizedTabs
             id="basic-tabs"
             className={basicTabStyle}
+            actionsToolbar={this.renderActions()}
             onSelect={tabValue => {
               this.setState({ currentTab: tabValue });
             }}

--- a/frontend/src/pages/NamespaceDetails/NamespaceDetailsPage.tsx
+++ b/frontend/src/pages/NamespaceDetails/NamespaceDetailsPage.tsx
@@ -434,11 +434,7 @@ export class NamespaceDetailsPageComponent extends React.Component<NamespaceDeta
 
     return (
       <>
-        <RenderHeader
-          actionsToolbar={actionsToolbar}
-          actionsToolbarTop="11.1rem"
-          rightToolbar={<TimeControl customDuration={false} />}
-        >
+        <RenderHeader rightToolbar={<TimeControl customDuration={false} />}>
           {!this.state.error && ns && (
             <div className={detailTitleRowStyle} data-test="namespace-detail-title-row">
               <div className={detailTitleMainStyle}>
@@ -457,6 +453,7 @@ export class NamespaceDetailsPageComponent extends React.Component<NamespaceDeta
           <ParameterizedTabs
             id="basic-tabs"
             className={basicTabStyle}
+            actionsToolbar={actionsToolbar}
             onSelect={tabValue => {
               this.setState({ currentTab: tabValue });
             }}

--- a/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/frontend/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -337,11 +337,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
 
     return (
       <>
-        <RenderHeader
-          rightToolbar={<TimeControl customDuration={useCustomTime} />}
-          actionsToolbar={actionsToolbar}
-          actionsToolbarTop="11.1rem"
-        >
+        <RenderHeader rightToolbar={<TimeControl customDuration={useCustomTime} />}>
           {this.state.serviceDetails && (
             <div className={detailTitleRowStyle}>
               <div className={detailTitleMainStyle}>
@@ -365,6 +361,7 @@ class ServiceDetailsPageComponent extends React.Component<ServiceDetailsProps, S
           <ParameterizedTabs
             id="basic-tabs"
             className={basicTabStyle}
+            actionsToolbar={actionsToolbar}
             onSelect={tabValue => {
               this.setState({ currentTab: tabValue });
             }}

--- a/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/frontend/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -424,11 +424,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
 
     return (
       <>
-        <RenderHeader
-          rightToolbar={<TimeControl customDuration={useCustomTime} />}
-          actionsToolbar={actionsToolbar}
-          actionsToolbarTop="11.1rem"
-        >
+        <RenderHeader rightToolbar={<TimeControl customDuration={useCustomTime} />}>
           {this.state.workload && (
             <div className={detailTitleRowStyle}>
               <div className={detailTitleMainStyle}>
@@ -447,6 +443,7 @@ class WorkloadDetailsPageComponent extends React.Component<WorkloadDetailsPagePr
           <ParameterizedTabs
             id="basic-tabs"
             className={basicTabStyle}
+            actionsToolbar={actionsToolbar}
             onSelect={tabValue => {
               this.setState({ currentTab: tabValue, cluster: this.state.cluster });
             }}


### PR DESCRIPTION
## Summary
- Removes the fragile absolute positioning of the actions toolbar in `RenderHeader` (which required a hardcoded `top: 11.1rem` override on detail pages).
- Moves the actions toolbar into `ParameterizedTabs`, where it renders at the tab bar level using container-relative positioning — no magic numbers.
- Adds a title row (badge + object name) to `IstioConfigDetailsPage` for consistency with Service, Workload, and Namespace detail pages.

<img width="1598" height="796" alt="image" src="https://github.com/user-attachments/assets/0f871294-ad41-45f0-868b-a34df4b27fb4" />

## Changes
- **`RenderHeader.tsx`**: Removed `actionsToolbar` prop and all related styles.
- **`Tabs.tsx`**: Added `actionsToolbar` prop to `ParameterizedTabs`, rendered at the top-right of the tabs container.
- **`ServiceDetailsPage`**, **`WorkloadDetailsPage`**, **`NamespaceDetailsPage`**: Moved `actionsToolbar` from `RenderHeader` to `ParameterizedTabs`.
- **`IstioConfigDetailsPage`**: Moved `actionsToolbar` to `ParameterizedTabs` and added a title row with the Istio config type badge and object name.

## Test plan
- [ ] Verify actions toolbar placement on Service details page
- [ ] Verify actions toolbar placement on Workload details page
- [ ] Verify actions toolbar placement on Namespace details page
- [ ] Verify actions toolbar and new title row on Istio Config details page
- [ ] Verify no visual regression on App details page (no actions toolbar)

Made with [Cursor](https://cursor.com)